### PR TITLE
Add Builder orders to Cachable Key

### DIFF
--- a/src/CachedBuilder.php
+++ b/src/CachedBuilder.php
@@ -27,6 +27,7 @@ class CachedBuilder extends EloquentBuilder
         $key .= $this->getQueryColumns($columns);
         $key .= $this->getWhereClauses();
         $key .= $this->getWithModels();
+        $key .= $this->getOrderClauses();
         $key .= $this->getOffsetClause();
         $key .= $this->getLimitClause();
 
@@ -117,6 +118,16 @@ class CachedBuilder extends EloquentBuilder
         return '-' . implode('-', $eagerLoads->keys()->toArray());
     }
 
+	protected function getOrderClauses(){
+        $orders = collect($this->query->orders);
+
+        return $orders->reduce(function($carry, $order){
+            $carry .= '_sort_' . array_get($order, 'column') . '_' . array_get($order, 'direction');
+
+            return $carry;
+        });
+    }
+	
     protected function getCacheTags() : array
     {
         return collect($this->eagerLoad)->keys()


### PR DESCRIPTION
Added `orderBy()` clauses to cachable, to cache sorted queries.