### PR TITLE
Feature/fix phpunit colors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "codedungeon/phpunit-result-printer": "^0.4.4",
+        "codedungeon/phpunit-result-printer": "0.5.3",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "orchestra/database": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "codedungeon/phpunit-result-printer": "0.5.3",
+        "codedungeon/phpunit-result-printer": "^0.5.3",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "orchestra/database": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "codedungeon/phpunit-result-printer": "^0.5.3",
+        "codedungeon/phpunit-result-printer": "*",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "orchestra/database": "^3.5",


### PR DESCRIPTION
The package `phpunit-result-printer` was not respecting `PHPUnit`'s specification of whether to colorize the output or not. This was a nuisance when piping the output of the unit tests to a pager or editor.
The updated version fixes that.