### PR TITLE
Move the logic into a trait, so it is accessible without extending the provided base model (eg for projects which already have a base model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mean that the entire cache is cleared each time a model is created, saved,
 updated, or deleted.
 
 For ease of maintenance, I would recommend adding a `BaseModel` model that
-extends `CachedModel`, from which all your other models are extended. If you
+uses `Cachable`, from which all your other models are extended. If you
 don't want to do that, simply extend your models directly from `CachedModel`.
 
 Here's an example `BaseModel` class:
@@ -57,10 +57,11 @@ Here's an example `BaseModel` class:
 ```php
 <?php namespace App;
 
-use GeneaLabs\LaravelModelCaching\CachedModel;
+use GeneaLabs\LaravelModelCaching\Traits\Cachable;
 
-abstract class BaseModel extends CachedModel
+abstract class BaseModel
 {
+    use Cachable;
     //
 }
 ```

--- a/src/CachedModel.php
+++ b/src/CachedModel.php
@@ -25,17 +25,4 @@ abstract class CachedModel extends Model
 
         return new Builder($query);
     }
-
-    public static function all($columns = ['*'])
-    {
-        $class = get_called_class();
-        $instance = new $class;
-        $tags = [str_slug(get_called_class())];
-        $key = $instance->makeCacheKey();
-
-        return $instance->cache($tags)
-            ->rememberForever($key, function () use ($columns) {
-                return parent::all($columns);
-            });
-    }
 }

--- a/src/CachedModel.php
+++ b/src/CachedModel.php
@@ -26,15 +26,6 @@ abstract class CachedModel extends Model
         return new Builder($query);
     }
 
-    public static function boot()
-    {
-        parent::boot();
-
-        static::saved(function ($instance) {
-            $instance->flushCache();
-        });
-    }
-
     public static function all($columns = ['*'])
     {
         $class = get_called_class();

--- a/src/CachedModel.php
+++ b/src/CachedModel.php
@@ -30,19 +30,7 @@ abstract class CachedModel extends Model
     {
         parent::boot();
 
-        static::created(function ($instance) {
-            $instance->flushCache();
-        });
-
-        static::deleted(function ($instance) {
-            $instance->flushCache();
-        });
-
         static::saved(function ($instance) {
-            $instance->flushCache();
-        });
-
-        static::updated(function ($instance) {
             $instance->flushCache();
         });
     }

--- a/src/CachedModel.php
+++ b/src/CachedModel.php
@@ -1,28 +1,9 @@
 <?php namespace GeneaLabs\LaravelModelCaching;
 
-use GeneaLabs\LaravelModelCaching\CachedBuilder as Builder;
 use GeneaLabs\LaravelModelCaching\Traits\Cachable;
-use Illuminate\Cache\CacheManager;
-use Illuminate\Cache\TaggableStore;
-use Illuminate\Cache\TaggedCache;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection;
-use LogicException;
 
 abstract class CachedModel extends Model
 {
     use Cachable;
-
-    public function newEloquentBuilder($query)
-    {
-        if (session('genealabs-laravel-model-caching-is-disabled')) {
-            session()->forget('genealabs-laravel-model-caching-is-disabled');
-
-            return new EloquentBuilder($query);
-        }
-
-        return new Builder($query);
-    }
 }

--- a/src/CachedModel.php
+++ b/src/CachedModel.php
@@ -30,22 +30,19 @@ abstract class CachedModel extends Model
     {
         parent::boot();
 
-        $class = get_called_class();
-        $instance = new $class;
-
-        static::created(function () use ($instance) {
+        static::created(function ($instance) {
             $instance->flushCache();
         });
 
-        static::deleted(function () use ($instance) {
+        static::deleted(function ($instance) {
             $instance->flushCache();
         });
 
-        static::saved(function () use ($instance) {
+        static::saved(function ($instance) {
             $instance->flushCache();
         });
 
-        static::updated(function () use ($instance) {
+        static::updated(function ($instance) {
             $instance->flushCache();
         });
     }

--- a/src/Traits/Cachable.php
+++ b/src/Traits/Cachable.php
@@ -60,4 +60,11 @@ trait Cachable
         return (new CacheTags($this->eagerLoad, $this->model))
             ->make();
     }
+
+    public static function bootCachable()
+    {
+        static::saved(function ($instance) {
+            $instance->flushCache();
+        });
+    }
 }

--- a/src/Traits/Cachable.php
+++ b/src/Traits/Cachable.php
@@ -67,4 +67,17 @@ trait Cachable
             $instance->flushCache();
         });
     }
+
+    public static function all($columns = ['*'])
+    {
+        $class = get_called_class();
+        $instance = new $class;
+        $tags = [str_slug(get_called_class())];
+        $key = $instance->makeCacheKey();
+
+        return $instance->cache($tags)
+            ->rememberForever($key, function () use ($columns) {
+                return parent::all($columns);
+            });
+    }
 }

--- a/src/Traits/Cachable.php
+++ b/src/Traits/Cachable.php
@@ -5,6 +5,8 @@ use GeneaLabs\LaravelModelCaching\CacheTags;
 use GeneaLabs\LaravelModelCaching\CachedModel;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use GeneaLabs\LaravelModelCaching\CachedBuilder;
 
 trait Cachable
 {
@@ -79,5 +81,16 @@ trait Cachable
             ->rememberForever($key, function () use ($columns) {
                 return parent::all($columns);
             });
+    }
+
+    public function newEloquentBuilder($query)
+    {
+        if (session('genealabs-laravel-model-caching-is-disabled')) {
+            session()->forget('genealabs-laravel-model-caching-is-disabled');
+
+            return new EloquentBuilder($query);
+        }
+
+        return new CachedBuilder($query);
     }
 }


### PR DESCRIPTION
mostly just moving the code into the cachable trait, altohugh also cleaned up the boot method a little

the model instance gets passed to the event listeners by laravel anyway, and saved gets called for all the events so no need to handle created/updated/deleted as well