### PR TITLE
remove unneeded check to make compatible with mongodb

### DIFF
--- a/src/Traits/Cachable.php
+++ b/src/Traits/Cachable.php
@@ -21,9 +21,7 @@ trait Cachable
         }
 
         if (is_subclass_of($cache->getStore(), TaggableStore::class)) {
-            if (is_a($this, CachedModel::class)) {
-                array_push($tags, str_slug(get_called_class()));
-            }
+            array_push($tags, str_slug(get_called_class()));
 
             $cache = $cache->tags($tags);
         }


### PR DESCRIPTION
In order for my mongodb models to be able to extend this trait, I had to make a CachedModel of my own as seen below

```
use GeneaLabs\LaravelModelCaching\CachedBuilder as Builder;
use GeneaLabs\LaravelModelCaching\Traits\Cachable;
use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
use Illuminate\Database\Eloquent\Model;
use Jenssegers\Mongodb\Eloquent\Model as Eloquent;

abstract class _CachedMongoModel extends Eloquent
{
    use Cachable;

    ... rest is the same as your CachedModel
}
```

But then the above check was a blocker. Upon inspection it seems like there's no reason to make this check since we can assume anyone using your trait is using it with your CachedModel (or an adapted clone as in my case)