### PR TITLE
typo fix in config/laravel-model-caching.php

### DIFF
--- a/config/laravel-model-caching.php
+++ b/config/laravel-model-caching.php
@@ -3,7 +3,7 @@
 return [
     'cache-prefix' => '',
 
-    'disabled' => env('MODEL_CACHE_STORE', false),
+    'disabled' => env('MODEL_CACHE_DISABLED', false),
 
     'store' => env('MODEL_CACHE_STORE'),
 ];


### PR DESCRIPTION
currently not retrieving the correct variable from .env file