### PR TITLE
dont cache if model::$isCachable == false

### DIFF
--- a/src/QueryOrModelCaller.php
+++ b/src/QueryOrModelCaller.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace GeneaLabs\LaravelModelCaching;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class QueryOrModelCaller
+{
+    /**
+     * @var CachedBuilder
+     */
+    protected $query;
+    /**
+     * @var Model
+     */
+    protected $model;
+    /**
+     * @var bool
+     */
+    protected $disableInConfig;
+
+    /**
+     * QueryOrModelCaller constructor.
+     *
+     * @param EloquentBuilder $query
+     * @param Model           $model
+     * @param bool            $disableInConfig
+     */
+    public function __construct(EloquentBuilder $query, Model $model, bool $disableInConfig)
+    {
+        $this->query = $query;
+        $this->model = $model;
+        $this->disableInConfig = $disableInConfig;
+    }
+
+    /**
+     * @param $name
+     * @param $arguments
+     *
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        if ($name == 'all')
+            $result = call_user_func_array([$this->model, 'all'], $arguments);
+        else
+            $result = call_user_func_array([$this->query, $name], $arguments);
+
+        config()->set('laravel-model-caching.disabled', $this->disableInConfig);
+
+        return $result;
+    }
+}

--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -7,12 +7,13 @@ trait ModelCaching
 {
     public static function all($columns = ['*'])
     {
-        if (config('laravel-model-caching.disabled')) {
+        $class = get_called_class();
+        $instance = new $class;
+
+        if (config('laravel-model-caching.disabled') || !$instance->isCachable) {
             return parent::all($columns);
         }
 
-        $class = get_called_class();
-        $instance = new $class;
         $tags = [str_slug(get_called_class())];
         $key = $instance->makeCacheKey();
 

--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -1,6 +1,7 @@
 <?php namespace GeneaLabs\LaravelModelCaching\Traits;
 
 use GeneaLabs\LaravelModelCaching\CachedBuilder;
+use GeneaLabs\LaravelModelCaching\QueryOrModelCaller;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 trait ModelCaching
@@ -53,13 +54,16 @@ trait ModelCaching
         return new CachedBuilder($query);
     }
 
-    public function scopeDisableCache(EloquentBuilder $query) : EloquentBuilder
+    public function scopeDisableCache(EloquentBuilder $query) : QueryOrModelCaller
     {
+        $disabledInConfig =  config('laravel-model-caching.disabled');
+
         if ($this->isCachable()) {
+            config()->set('laravel-model-caching.disabled', true);
             $query = $query->disableModelCaching();
         }
 
-        return $query;
+        return new QueryOrModelCaller($query, $this, $disabledInConfig);
     }
 
     public function scopeWithCacheCooldownSeconds(


### PR DESCRIPTION
When calling model::all(), the $isCachable property on the model wasn't checked, resulting in model:all() results to be cached, even when $isCachable was set to false. 

This PR attempts to fix that :)