### PR TITLE
Multiple Database Connections: Extension

### DIFF
--- a/src/Traits/CachePrefixing.php
+++ b/src/Traits/CachePrefixing.php
@@ -13,6 +13,6 @@ trait CachePrefixing
 
     protected function getDatabaseConnectionName() : string
     {
-        return $this->query->connection->getName();
+        return $this->query->connection->getDatabaseName();
     }
 }


### PR DESCRIPTION
I changed the connection name to the database name. This would be more flexible if a tenant system use for every tenant the same connection name and only changed the database in the connection.
This change has no disadvantages compared to the previous variant