### PR TITLE
Lumen support

### DIFF
--- a/src/Console/Commands/Clear.php
+++ b/src/Console/Commands/Clear.php
@@ -21,7 +21,7 @@ class Clear extends Command
 
     protected function flushEntireCache() : int
     {
-        cache()
+        app('cache')
             ->store(config('laravel-model-caching.store'))
             ->flush();
 

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -13,7 +13,7 @@ trait Caching
 
     public function cache(array $tags = [])
     {
-        $cache = cache();
+        $cache = app('cache');
 
         if (config('laravel-model-caching.store')) {
             $cache = $cache->store(config('laravel-model-caching.store'));
@@ -70,7 +70,7 @@ trait Caching
     ) : string {
         $eagerLoad = $this->eagerLoad ?? [];
         $model = $this->model ?? $this;
-        $query = $this->query ?? app(Builder::class);
+        $query = $this->query ?? app('db')->query();
 
         return (new CacheKey($eagerLoad, $model, $query))
             ->make($columns, $idColumn, $keyDifferentiator);
@@ -80,7 +80,7 @@ trait Caching
     {
         $eagerLoad = $this->eagerLoad ?? [];
         $model = $this->model ?? $this;
-        $query = $this->query ?? app(Builder::class);
+        $query = $this->query ?? app('db')->query();
 
         $tags = (new CacheTags($eagerLoad, $model, $query))
             ->make();

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -14,7 +14,7 @@ trait CreatesApplication
 
     protected function cache()
     {
-        $cache = cache();
+        $cache = app('cache');
 
         if (config('laravel-model-caching.store')) {
             $cache = $cache->store(config('laravel-model-caching.store'));
@@ -33,7 +33,7 @@ trait CreatesApplication
         $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
         view()->addLocation(__DIR__ . '/resources/views', 'laravel-model-caching');
 
-        $this->cache = cache()
+        $this->cache = app('cache')
             ->store(config('laravel-model-caching.store'));
 
         $this->cache()->flush();

--- a/tests/Integration/Traits/CachableTest.php
+++ b/tests/Integration/Traits/CachableTest.php
@@ -31,10 +31,10 @@ class CachableTest extends IntegrationTestCase
 
         $authors = (new Author)
             ->all();
-        $defaultcacheResults = cache()
+        $defaultcacheResults = app('cache')
             ->tags($tags)
             ->get($key)['value'];
-        $customCacheResults = cache()
+        $customCacheResults = app('cache')
             ->store('customCache')
             ->tags($tags)
             ->get($key)['value'];
@@ -51,7 +51,7 @@ class CachableTest extends IntegrationTestCase
         (new PrefixedAuthor)->get();
 
         $results = $this->
-            cache()
+            app('cache')
             ->tags([
                 'genealabs:laravel-model-caching:testing::memory::test-prefix:genealabslaravelmodelcachingtestsfixturesprefixedauthor',
             ])

--- a/tests/Integration/Traits/CachableTest.php
+++ b/tests/Integration/Traits/CachableTest.php
@@ -51,7 +51,7 @@ class CachableTest extends IntegrationTestCase
         (new PrefixedAuthor)->get();
 
         $results = $this->
-            app('cache')
+            cache()
             ->tags([
                 'genealabs:laravel-model-caching:testing::memory::test-prefix:genealabslaravelmodelcachingtestsfixturesprefixedauthor',
             ])


### PR DESCRIPTION
This PR fixes several issues, that i found working with Lumen.
1. Lumen don't have `cache()` helper.
2. [This issue](https://github.com/GeneaLabs/laravel-model-caching/issues/148).