### PR TITLE
Fixed missing function bug in Lumen.

### DIFF
--- a/src/CachedBuilder.php
+++ b/src/CachedBuilder.php
@@ -150,7 +150,7 @@ class CachedBuilder extends EloquentBuilder
             return parent::paginate($perPage, $columns, $pageName, $page);
         }
 
-        $page = request()->input($pageName)
+        $page = app('request')->input($pageName)
             ?: $page
             ?: 1;
 


### PR DESCRIPTION
This PR fixed a Lumen bug mentioned in Issue #198 . 
Changed `request()` helper function into `app('request')`