### PR TITLE
Fix never forget cooldown seconds in checkCooldownAndRemoveIfExpired.

### DIFF
--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -138,7 +138,7 @@ trait Caching
 
         $instance
             ->cache()
-            ->forget("{$cachePrefix}:{$modelClassName}-cooldown:invalidated-at");
+            ->forget("{$cachePrefix}:{$modelClassName}-cooldown:seconds");
         $instance
             ->cache()
             ->forget("{$cachePrefix}:{$modelClassName}-cooldown:invalidated-at");


### PR DESCRIPTION
I execute `${cachableModel}->scopeWithCacheCooldownSeconds`.
But `cooldown seconds` never been changed.
So, I found this problem in `Caching::checkCooldownAndRemoveIfExpired`.
(Maybe copy and paste code but not changed from `cooldown:invalidated-at` to `cooldown:seconds` ?)
