### PR TITLE
Fix incorrect cache key in multiple DB connection.

### DIFF
--- a/src/Traits/CachePrefixing.php
+++ b/src/Traits/CachePrefixing.php
@@ -14,11 +14,11 @@ trait CachePrefixing
 
     protected function getDatabaseConnectionName() : string
     {
-        return $this->query->connection->getName();
+        return $this->model->getConnection()->getName();
     }
 
     protected function getDatabaseName() : string
     {
-        return $this->query->connection->getDatabaseName();
+        return $this->model->getConnection()->getDatabaseName();
     }
 }


### PR DESCRIPTION
This PR fixed a `makeCacheKey` bug mentioned in Issue #212.
It used default DB connection to make query instead of using `$connection` in model.