### PR TITLE
Laravel may return either an object or a collection. If laravel-model…

### DIFF
--- a/src/CachedBuilder.php
+++ b/src/CachedBuilder.php
@@ -61,7 +61,8 @@ class CachedBuilder extends EloquentBuilder
         }
 
         $idKey = collect($id)->implode('-');
-        $cacheKey = $this->makeCacheKey($columns, null, "-find_{$idKey}");
+        $preStr = is_array($id) ? 'find-list' : 'find';
+        $cacheKey = $this->makeCacheKey($columns, null, "-" . $preStr . "_{$idKey}");
 
         return $this->cachedValue(func_get_args(), $cacheKey);
     }


### PR DESCRIPTION
…-caching uses the same cache key, it will return one of the two. See the comments by @zhenyangze at https://github.com/GeneaLabs/laravel-model-caching/issues/204#issue-402979412. This is just a simple commit to make a pull request for his recommended fix.