### PR TITLE
Handle whereIn when collection is empty

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -215,7 +215,7 @@ class CacheKey
 
         $type = strtolower($where["type"]);
         $subquery = $this->getValuesFromWhere($where);
-        $values = collect($this->query->bindings["where"][$this->currentBinding]);
+        $values = collect($this->query->bindings["where"][$this->currentBinding] ?? []);
         $this->currentBinding++;
         $subquery = collect(vsprintf(str_replace("?", "%s", $subquery), $values->toArray()));
         $values = $this->recursiveImplode($subquery->toArray(), "_");

--- a/tests/Integration/CachedBuilder/WhereInTest.php
+++ b/tests/Integration/CachedBuilder/WhereInTest.php
@@ -41,4 +41,30 @@ class WhereInTest extends IntegrationTestCase
         $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
         $this->assertEquals($liveResults->pluck("id"), $cachedResults->pluck("id"));
     }
+
+
+    public function testWithInWhenSetIsEmpty()
+    {
+        $key = sha1('genealabs:laravel-model-caching:testing::memory::books:genealabslaravelmodelcachingtestsfixturesbook-author_id_in_1_2_3_4');
+        $tags = [
+            'genealabs:laravel-model-caching:testing::memory::genealabslaravelmodelcachingtestsfixturesbook',
+        ];
+        $authors = (new UncachedAuthor)
+            ->where("id", "<", 0)
+            ->get(["id"]);
+
+        $books = (new Book)
+            ->whereIn("author_id", $authors)
+            ->get();
+        $cachedResults = $this
+                             ->cache()
+                             ->tags($tags)
+                             ->get($key)['value'];
+        $liveResults = (new UncachedBook)
+            ->whereIn("author_id", $authors)
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+        $this->assertNull($cachedResults);
+    }
 }


### PR DESCRIPTION
Currently, when running a `whereIn`, where the collection checking against is empty an exception will be thrown. This fixes the issue, evidenced by the test.