### PR TITLE
When model cache disabled, it is correctly disabled on query and all eager loaded relations

### DIFF
--- a/src/CachedBuilder.php
+++ b/src/CachedBuilder.php
@@ -166,6 +166,25 @@ class CachedBuilder extends EloquentBuilder
         return $this->cachedValue(func_get_args(), $cacheKey);
     }
 
+	/**
+	 * Get the relation instance for the given relation name.
+	 * This is overloaded so we can disable model cache on
+	 * relations if parent has disabled model caching.
+	 *
+	 * @param  string  $name
+	 * @return \Illuminate\Database\Eloquent\Relations\Relation
+	 */
+	public function getRelation($name)
+	{
+		$relation = parent::getRelation($name);
+
+		if(!$this->isCachable() && is_a($relation->getQuery(), self::class)){
+			$relation->getQuery()->disableModelCaching();
+		}
+
+		return $relation;
+	}
+
     protected function recursiveImplodeWithKey(array $items, string $glue = "_") : string
     {
         $result = "";

--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -69,7 +69,7 @@ trait ModelCaching
     public function newEloquentBuilder($query)
     {
         if (! $this->isCachable()) {
-            $this->isCachable = true;
+            $this->isCachable = false;
 
             return new EloquentBuilder($query);
         }


### PR DESCRIPTION
This is an attempt to fix the reason why `scopeDisableCache()` global scope is not working.

@mikebronner if this is supposed to be actually set to `true` for some reason, let me know. I believe it is meant to be false though.

See #106 and #231 