### PR TITLE
Fix model connection for SQLite tests

### DIFF
--- a/src/Traits/CachePrefixing.php
+++ b/src/Traits/CachePrefixing.php
@@ -28,7 +28,7 @@ trait CachePrefixing
 
     protected function getDatabaseName() : string
     {
-        return $this->query->getConnection()->getDatabaseName();
+        return $this->model->getConnection()->getDatabaseName();
     }
 
     protected function getConnectionName() : string


### PR DESCRIPTION
While running integration and feature tests using SQLite driver and the query is not completed initialized in a multitenant scenario and for example the output of `$this->query->toSql()` will be `select *` or `1`, this will fallback to the default connection instead of using the proper model connection.

Fix #272 