### PR TITLE
Allow a model to optionally specify a maximum cache timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /vendor
 composer.lock
+.idea

--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -40,7 +40,10 @@ trait ModelCaching
 
     public static function maxCacheTimeout()
     {
-        return static::$maxCacheTimeout ?? 0;
+        if (property_exists(get_called_class(), 'maxCacheTimeout')) {
+            return static::$maxCacheTimeout ?: 0;
+        }
+        return 0;
     }
 
     public static function all($columns = ['*'])

--- a/tests/Fixtures/MaxCacheBook.php
+++ b/tests/Fixtures/MaxCacheBook.php
@@ -1,0 +1,58 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use GeneaLabs\LaravelModelCaching\Traits\Cachable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class MaxCacheBook extends Model
+{
+    use Cachable;
+    protected static $maxCacheTimeout = 2; // Specify the max seconds after which to timeout
+
+    protected $casts = [
+        'price' => 'float',
+    ];
+    protected $dates = [
+        'published_at',
+    ];
+    protected $fillable = [
+        'description',
+        'published_at',
+        'title',
+        'price',
+    ];
+    protected $table = 'books';
+
+    public function author() : BelongsTo
+    {
+        return $this->belongsTo(Author::class);
+    }
+
+    public function comments() : MorphMany
+    {
+        return $this->morphMany(Comment::class, "commentable");
+    }
+
+    public function image() : MorphOne
+    {
+        return $this->morphOne(Image::class, "imagable");
+    }
+
+    public function publisher() : BelongsTo
+    {
+        return $this->belongsTo(Publisher::class);
+    }
+
+    public function stores() : BelongsToMany
+    {
+        return $this->belongsToMany(Store::class);
+    }
+
+    public function uncachedStores() : BelongsToMany
+    {
+        return $this->belongsToMany(UncachedStore::class, "book_store", "book_id", "store_id");
+    }
+}

--- a/tests/Integration/CachedBuilder/MaxExpireTest.php
+++ b/tests/Integration/CachedBuilder/MaxExpireTest.php
@@ -1,0 +1,47 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\MaxCacheBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
+
+class MaxCacheTest extends IntegrationTestCase
+{
+    public function testWithQuery()
+    {
+        $maxcached_book = MaxCacheBook::query()->find(1);
+        $original_maxcached_book_price = $maxcached_book->price;
+
+        DB::update(DB::raw("UPDATE `books` SET `price` = (`price` + 1.25) WHERE `id` = 1"));
+
+        // Re-pull maxcached book and verify cache hasn't changed despite raw update
+        $maxcached_book = MaxCacheBook::query()->find(1);
+        $this->assertEquals($original_maxcached_book_price, $maxcached_book->price);
+
+        sleep(MaxCacheBook::maxCacheTimeout()); // Not great, is there a better way?
+
+        $maxcached_book = MaxCacheBook::query()->find(1);
+
+        //Cache should now have expired and the cached value should have changed
+        $this->assertEquals($original_maxcached_book_price + 1.25, $maxcached_book->price);
+    }
+
+    public function testWithAll()
+    {
+        $maxcached_book = MaxCacheBook::all()->where('id', 1)->first();
+        $original_maxcached_book_price = $maxcached_book->price;
+
+        DB::update(DB::raw("UPDATE `books` SET `price` = (`price` + 1.25) WHERE `id` = 1"));
+
+        // Re-pull maxcached book and verify cache hasn't changed despite raw update
+        $maxcached_book = MaxCacheBook::all()->where('id', 1)->first();
+
+        $this->assertEquals($original_maxcached_book_price, $maxcached_book->price);
+
+        sleep(MaxCacheBook::maxCacheTimeout()); // Not great, is there a better way?
+
+        $maxcached_book = MaxCacheBook::all()->where('id', 1)->first();
+
+        //Cache should now have expired and the cached value should have changed
+        $this->assertEquals($original_maxcached_book_price + 1.25, $maxcached_book->price);
+    }
+}


### PR DESCRIPTION
We are in the process of migrating some legacy parts of our code base in to Laravel and to use cached models, some of this legacy code uses raw queries to update data we want to use cached models with.  This gives us a way to move to cached model code in Laravel while we migrate the legacy raw queries; by adding a single `protected static $maxCacheTimeout = 300;` to our cacheable model we can be sure that the raw updates will eventually, 300s from original cache, be reflected on the cached frontend.  Allowing this to be defined per model means we can use fully cached models on new code/tables and use caching as we migrate older code over.