### PR TITLE
Parameter $columns can be a string, and must be converted to expected array

### DIFF
--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Arr;
 
 trait Caching
 {
@@ -130,7 +131,7 @@ trait Caching
     }
 
     protected function makeCacheKey(
-        array $columns = ['*'],
+        $columns = ['*'],
         $idColumn = null,
         string $keyDifferentiator = ''
     ) : string {
@@ -158,7 +159,7 @@ trait Caching
         }
 
         return (new CacheKey($eagerLoad, $model, $query, $this->macroKey))
-            ->make($columns, $idColumn, $keyDifferentiator);
+            ->make(Arr::wrap($columns), $idColumn, $keyDifferentiator);
     }
 
     protected function makeCacheTags() : array


### PR DESCRIPTION
With Eloquent you can do both of these:
Model::where('id', $id)->get(['column'])
Model::where('id', $id)->get('column')

Builder is converting it.
https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Query/Builder.php#L2117

But makeCacheKey() is expecting array.

I took the same approach that laravel has, into makeCacheKey().
