### PR TITLE
Fixed string template syntax in CachedBuilderTest

### DIFF
--- a/tests/Feature/PaginationTest.php
+++ b/tests/Feature/PaginationTest.php
@@ -2,27 +2,19 @@
 
 use GeneaLabs\LaravelModelCaching\Tests\FeatureTestCase;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
-use Illuminate\Support\Str;
 
 class PaginationTest extends FeatureTestCase
 {
     public function testPaginationProvidesDifferentLinksOnDifferentPages()
     {
-        if (Str::startsWith(app()->version(), "5.6")
-            || Str::startsWith(app()->version(), "5.7")
-            || Str::startsWith(app()->version(), "5.8")
-            || Str::startsWith(app()->version(), "6.0")
-        ) {
+        // Checking the version start with 5.6, 5.7, 5.8 or 6.
+        if (preg_match("/^((5\.[6-8])|(6\.))/", app()->version())) {
             $page1ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">1</span></li>';
             $page2ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">2</span></li>';
         }
 
-        if (Str::startsWith(app()->version(), "5.5")) {
-            $page1ActiveLink = '<li class="active"><span>1</span></li>';
-            $page2ActiveLink = '<li class="active"><span>2</span></li>';
-        }
-
-        if (Str::startsWith(app()->version(), "5.4")) {
+        // Checking the version 5.4 and 5.5
+        if (preg_match("/^5\.[4-5]/", app()->version())) {
             $page1ActiveLink = '<li class="active"><span>1</span></li>';
             $page2ActiveLink = '<li class="active"><span>2</span></li>';
         }
@@ -41,21 +33,12 @@ class PaginationTest extends FeatureTestCase
 
     public function testAdvancedPagination()
     {
-        if (Str::startsWith(app()->version(), "5.6")
-            || Str::startsWith(app()->version(), "5.7")
-            || Str::startsWith(app()->version(), "5.8")
-            || Str::startsWith(app()->version(), "6.0")
-        ) {
+        if (preg_match("/^((5\.[6-8])|(6\.))/", app()->version())) {
             $page1ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">1</span></li>';
             $page2ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">2</span></li>';
         }
 
-        if (Str::startsWith(app()->version(), "5.5")) {
-            $page1ActiveLink = '<li class="active"><span>1</span></li>';
-            $page2ActiveLink = '<li class="active"><span>2</span></li>';
-        }
-
-        if (Str::startsWith(app()->version(), "5.4")) {
+        if (preg_match("/^5\.[4-5]/", app()->version())) {
             $page1ActiveLink = '<li class="active"><span>1</span></li>';
             $page2ActiveLink = '<li class="active"><span>2</span></li>';
         }
@@ -67,21 +50,12 @@ class PaginationTest extends FeatureTestCase
 
     public function testCustomPagination()
     {
-        if (Str::startsWith(app()->version(), "5.6")
-            || Str::startsWith(app()->version(), "5.7")
-            || Str::startsWith(app()->version(), "5.8")
-            || Str::startsWith(app()->version(), "6.0")
-        ) {
+        if (preg_match("/^((5\.[6-8])|(6\.))/", app()->version())) {
             $page1ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">1</span></li>';
             $page2ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">2</span></li>';
         }
 
-        if (Str::startsWith(app()->version(), "5.5")) {
-            $page1ActiveLink = '<li class="active"><span>1</span></li>';
-            $page2ActiveLink = '<li class="active"><span>2</span></li>';
-        }
-
-        if (Str::startsWith(app()->version(), "5.4")) {
+        if (preg_match("/^5\.[4-5]/", app()->version())) {
             $page1ActiveLink = '<li class="active"><span>1</span></li>';
             $page2ActiveLink = '<li class="active"><span>2</span></li>';
         }

--- a/tests/Integration/CachedBuilder/PaginateTest.php
+++ b/tests/Integration/CachedBuilder/PaginateTest.php
@@ -36,23 +36,13 @@ class PaginateTest extends IntegrationTestCase
 
     public function testPaginationReturnsCorrectLinks()
     {
-        if (Str::startsWith(app()->version(), "5.6")
-            || Str::startsWith(app()->version(), "5.7")
-            || Str::startsWith(app()->version(), "5.8")
-            || Str::startsWith(app()->version(), "6.0")
-        ) {
+        if (preg_match("/^((5\.[6-8])|(6\.))/", app()->version())) {
             $page1ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">1</span></li>';
             $page2ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">2</span></li>';
             $page24ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">24</span></li>';
         }
 
-        if (Str::startsWith(app()->version(), "5.5")) {
-            $page1ActiveLink = '<li class="active"><span>1</span></li>';
-            $page2ActiveLink = '<li class="active"><span>2</span></li>';
-            $page24ActiveLink = '<li class="active"><span>24</span></li>';
-        }
-
-        if (Str::startsWith(app()->version(), "5.4")) {
+        if (preg_match("/^5\.[4-5]/", app()->version())) {
             $page1ActiveLink = '<li class="active"><span>1</span></li>';
             $page2ActiveLink = '<li class="active"><span>2</span></li>';
             $page24ActiveLink = '<li class="active"><span>24</span></li>';
@@ -75,23 +65,13 @@ class PaginateTest extends IntegrationTestCase
 
     public function testPaginationWithOptionsReturnsCorrectLinks()
     {
-        if (Str::startsWith(app()->version(), "5.6")
-            || Str::startsWith(app()->version(), "5.7")
-            || Str::startsWith(app()->version(), "5.8")
-            || Str::startsWith(app()->version(), "6.0")
-        ) {
+        if (preg_match("/^((5\.[6-8])|(6\.))/", app()->version())) {
             $page1ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">1</span></li>';
             $page2ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">2</span></li>';
             $page24ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">24</span></li>';
         }
 
-        if (Str::startsWith(app()->version(), "5.5")) {
-            $page1ActiveLink = '<li class="active"><span>1</span></li>';
-            $page2ActiveLink = '<li class="active"><span>2</span></li>';
-            $page24ActiveLink = '<li class="active"><span>24</span></li>';
-        }
-
-        if (Str::startsWith(app()->version(), "5.4")) {
+        if (preg_match("/^5\.[4-5]/", app()->version())) {
             $page1ActiveLink = '<li class="active"><span>1</span></li>';
             $page2ActiveLink = '<li class="active"><span>2</span></li>';
             $page24ActiveLink = '<li class="active"><span>24</span></li>';
@@ -114,23 +94,13 @@ class PaginateTest extends IntegrationTestCase
 
     public function testPaginationWithCustomOptionsReturnsCorrectLinks()
     {
-        if (Str::startsWith(app()->version(), "5.6")
-            || Str::startsWith(app()->version(), "5.7")
-            || Str::startsWith(app()->version(), "5.8")
-            || Str::startsWith(app()->version(), "6.0")
-        ) {
+        if (preg_match("/^((5\.[6-8])|(6\.))/", app()->version())) {
             $page1ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">1</span></li>';
             $page2ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">2</span></li>';
             $page24ActiveLink = '<li class="page-item active" aria-current="page"><span class="page-link">24</span></li>';
         }
 
-        if (Str::startsWith(app()->version(), "5.5")) {
-            $page1ActiveLink = '<li class="active"><span>1</span></li>';
-            $page2ActiveLink = '<li class="active"><span>2</span></li>';
-            $page24ActiveLink = '<li class="active"><span>24</span></li>';
-        }
-
-        if (Str::startsWith(app()->version(), "5.4")) {
+        if (preg_match("/^5\.[4-5]/", app()->version())) {
             $page1ActiveLink = '<li class="active"><span>1</span></li>';
             $page2ActiveLink = '<li class="active"><span>2</span></li>';
             $page24ActiveLink = '<li class="active"><span>24</span></li>';

--- a/tests/Integration/CachedBuilderTest.php
+++ b/tests/Integration/CachedBuilderTest.php
@@ -49,7 +49,7 @@ class CachedBuilderTest extends IntegrationTestCase
             ])
             ->get(sha1(
                 "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor_1_2_3_4_5_6_" .
-                '7_8_9_10-genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbooks'
+                "7_8_9_10-genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbooks"
             ));
 
         $this->assertNull($results);
@@ -67,7 +67,7 @@ class CachedBuilderTest extends IntegrationTestCase
             ])
             ->get(sha1(
                 "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor_1_2_3_4_5_6_" .
-                '7_8_9_10-genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbooks'
+                "7_8_9_10-genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbooks"
             ));
 
         $this->assertNull($results);
@@ -84,7 +84,7 @@ class CachedBuilderTest extends IntegrationTestCase
             ])
             ->get(sha1(
                 "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor_1_2_3_4_5_6_" .
-                '7_8_9_10-genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbooks'
+                "7_8_9_10-genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbooks"
             ));
 
         $this->assertNull($results);


### PR DESCRIPTION
While working on the non cacheable test I submitted earlier I noticed that a couple of the tests used `'` instead of `"` which would stop the variable parsing.