### PR TITLE
Skip adding currentBinding if the where values are not in the query binding

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -234,7 +234,10 @@ class CacheKey
         $type = strtolower($where["type"]);
         $subquery = $this->getValuesFromWhere($where);
         $values = collect($this->query->bindings["where"][$this->currentBinding] ?? []);
-        $this->currentBinding += count($where["values"]);
+
+        if (Str::startsWith($subquery, $values->first())) {
+            $this->currentBinding += count($where["values"]);
+        }
 
         if (! is_numeric($subquery) && ! is_numeric(str_replace("_", "", $subquery))) {
             try {


### PR DESCRIPTION
- Skip adding currentBinding in the CacheKey class if the where values are not in the query binding.