### PR TITLE
Fix PHP 7.2 action 

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -10,17 +10,17 @@ jobs:
   laravel-tests:
 
     runs-on: ubuntu-latest
-    
+
     strategy:
       fail-fast: true
       matrix:
-        php: ['^7.2.5', 7.3, 7.4]
-    
+        php: [7.2, 7.3, 7.4]
+
     name: PHP ${{ matrix.php }}
-    
+
     steps:
     - uses: actions/checkout@v2
-      
+
     - name: Cache dependencies
       uses: actions/cache@v1
       with:
@@ -33,31 +33,31 @@ jobs:
         php-version: ${{ matrix.php }}
         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, pgsql, pdo_pgsql
         coverage: none
-      
+
     - uses: zhulik/redis-action@1.1.0
       with:
         redis version: '5'
         number of databases: 100
-    
+
     - uses: harmon758/postgresql-action@v1
       with:
         postgresql version: '11'
         postgresql db: 'testing'
         postgresql user: 'homestead'
-        postgresql password: 'secret'    
-    
+        postgresql password: 'secret'
+
     - name: Remove Nova on a pull request
       if: github.event_name == 'pull_request'
       run: composer remove laravel/nova --no-update --no-interaction --dev
-    
+
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
-    
+
     - name: Install Dependencies
       run: |
         composer config "http-basic.nova.laravel.com" "${{ secrets.NOVA_USERNAME }}" "${{ secrets.NOVA_PASSWORD }}"
         composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-    
+
     - name: Execute Integration and Feature tests via PHPUnit
       run: vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite Integration,Feature
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "php-coveralls/php-coveralls" : "^2.2",
         "phpmd/phpmd": "^2.7",
         "phpunit/phpunit": "^8.0",
-        "sebastian/phpcpd": "^5.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/thanks": "^1.2"
     },


### PR DESCRIPTION
Fixes #348 

I have had to remove a dev dependency that was causing composer to fail install.

https://github.com/sebastianbergmann/phpcpd

I tried changing version to `^4.0|^5.0` but composer still failed.

If you are using this somewhere externally you will have to find a workaround for php 7.2. 