### PR TITLE
Add some code to stop scopes from being applied twice.

### DIFF
--- a/src/Traits/Buildable.php
+++ b/src/Traits/Buildable.php
@@ -292,4 +292,19 @@ trait Buildable
                 }
             );
     }
+
+    /**
+     * Apply the scopes if they haven't already been applied, if they have
+     * just return the builder. This prevents scopes from being applied twice.
+     *
+     * @return static
+     */
+    public function applyScopes()
+    {
+        if ($this->scopesAreApplied) {
+            return $this;
+        }
+        
+        return parent::applyScopes();
+    }
 }

--- a/tests/Integration/CachedBuilder/ScopeTest.php
+++ b/tests/Integration/CachedBuilder/ScopeTest.php
@@ -8,6 +8,7 @@ use GeneaLabs\LaravelModelCaching\Tests\Fixtures\AuthorWithInlineGlobalScope;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthorWithInlineGlobalScope;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\User;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class ScopeTest extends IntegrationTestCase
@@ -173,5 +174,18 @@ class ScopeTest extends IntegrationTestCase
 
         // $this->assertNotEquals($authors1, $authors2);
         $this->markTestSkipped();
+    }
+
+    public function testScopeNotAppliedTwice()
+    {
+        factory(Author::class, 10)->create();
+        $user = factory(User::class)->create(["name" => "Anton Junior"]);
+        $this->actingAs($user);
+        DB::enableQueryLog();
+        $authorsA = (new AuthorBeginsWithScoped)
+            ->get();
+        $queryLog = DB::getQueryLog();
+        $this->assertCount(1, $queryLog);
+        $this->assertCount(1, $queryLog[0]['bindings'], "There should only be 1 binding, scope is being applied more than once.");
     }
 }


### PR DESCRIPTION
This should fix #289 by overriding the builders implementation of `applyScopes()` to make it check if scopes have been applied already before attempting to apply them again.