### PR TITLE
Fix newBelongsToMany method compatibility

### DIFF
--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -3,6 +3,7 @@
 use GeneaLabs\LaravelModelCaching\CachedBelongsToMany;
 use GeneaLabs\LaravelModelCaching\CachedBuilder;
 use GeneaLabs\LaravelModelCaching\EloquentBuilder;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
@@ -108,7 +109,7 @@ trait ModelCaching
     }
 
     protected function newBelongsToMany(
-        EloquentBuilder $query,
+        Builder $query,
         Model $parent,
         $table,
         $foreignPivotKey,


### PR DESCRIPTION
Fixes #381 

So this changes the method signature to use the `Eloquent/Builder` class directly in the method signature rather than the alias. 

I created an example repo to replicate this issue here:
https://github.com/dmason30/model-caching-example

This is the test used:
https://github.com/dmason30/model-caching-example/blob/master/tests/Unit/ExampleTest.php

**Before fix**
Replicated action: https://github.com/dmason30/model-caching-example/runs/1359149642?check_suite_focus=true
<details>
<summary>Shows PHP 7.3 Warning</summary>

![image](https://user-images.githubusercontent.com/20278756/98268419-67a5df00-1f84-11eb-8a1b-0e9f40f47bee.png)
</details>

<details>
<summary>Shows PHP 7.4 Warning</summary>

![image](https://user-images.githubusercontent.com/20278756/98268543-8f954280-1f84-11eb-826f-02167b872ea8.png)
</details>

**After fix**
Example repo changed to use fork: https://github.com/dmason30/model-caching-example/pull/1/files
Fix action: https://github.com/dmason30/model-caching-example/runs/1359345868?check_suite_focus=true
<details>
<summary>Shows PHP 7.3  No warnings</summary>

![image](https://user-images.githubusercontent.com/20278756/98268711-c5d2c200-1f84-11eb-87d4-7fd6c3ec50e0.png)
</details>

<details>
<summary>Shows PHP 7.4 No warnings</summary>

![image](https://user-images.githubusercontent.com/20278756/98268836-e7cc4480-1f84-11eb-9769-1a5220628f88.png)
</details>