### PR TITLE
Use the part of the query (->from) instead of the table name of the model (->table)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2021-03-16
+### Changed
+- The from part of the query ($query->from) instead of the table name of the model ($model->table)
+  is now used for determining the table part caching key fragment
+
 ## [0.10.2] - 2020-09-04
 ### Added
 - functionality to inject custom builder class for handling conflicting packages.

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -69,7 +69,7 @@ class CacheKey
 
     protected function getTableSlug() : string
     {
-        return (new Str)->slug($this->model->getTable())
+        return (new Str)->slug($this->query->from)
             . ":";
     }
 


### PR DESCRIPTION
Why ?

I have the following model:

```php
class DemoUnscoped {
        public $table = 'demo_unscoped';

	public function scopeFooBar($query)
	{
		$query->from('demo_scoped');

		return $query;
	}
}
```

Now, assuming my table demo_unscoped has 666 entries, and demo_scoped has 999 entries, prior to this patch i get the following results:

```
DemoUnscoped::count();
666
DemoUnscoped::FooBar()->count();
666 // <----------- WRONG (has cached the value but should not!)
```

With this fix applied i get:


```
DemoUnscoped::count();
666
DemoUnscoped::FooBar()->count();
999 // <----------- Correct ! 
```
