### PR TITLE
[bug] Fix current binding count when previous binding is false

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -69,7 +69,7 @@ class CacheKey
         return "-{$where["boolean"]}_{$where["first"]}_{$where["operator"]}_{$where["second"]}";
     }
 
-    protected function getCurrentBinding(string $type, string $bindingFallback): string
+    protected function getCurrentBinding(string $type, mixed $bindingFallback = null): mixed
     {
         return data_get($this->query->bindings, "{$type}.{$this->currentBinding}", $bindingFallback);
     }
@@ -87,7 +87,7 @@ class CacheKey
 
         $type = strtolower($where["type"]);
         $subquery = $this->getValuesFromWhere($where);
-        $values = collect($this->getCurrentBinding('where', ""));
+        $values = collect($this->getCurrentBinding('where', []));
 
         if (Str::startsWith($subquery, $values->first())) {
             $this->currentBinding += count($where["values"]);
@@ -210,7 +210,7 @@ class CacheKey
 
         while (count($queryParts) > 1) {
             $clause .= "_" . array_shift($queryParts);
-            $clause .= $this->getCurrentBinding("where", "");
+            $clause .= $this->getCurrentBinding("where");
             $this->currentBinding++;
         }
 
@@ -282,7 +282,7 @@ class CacheKey
             $this->currentBinding++;
 
             if ($where["type"] === "between") {
-                $values .= "_" . $this->getCurrentBinding("where", "");
+                $values .= "_" . $this->getCurrentBinding("where");
                 $this->currentBinding++;
             }
         }

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -87,7 +87,7 @@ class CacheKey
 
         $type = strtolower($where["type"]);
         $subquery = $this->getValuesFromWhere($where);
-        $values = collect($this->getCurrentBinding('where', []));
+        $values = collect($this->getCurrentBinding('where', ""));
 
         if (Str::startsWith($subquery, $values->first())) {
             $this->currentBinding += count($where["values"]);

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -51,9 +51,64 @@ class CacheKey
         return $key;
     }
 
+    protected function getBindingsSlug() : string
+    {
+        if (! method_exists($this->model, 'query')) {
+            return '';
+        }
+
+        return Arr::query($this->model->query()->getBindings());
+    }
+
+    protected function getColumnClauses(array $where) : string
+    {
+        if ($where["type"] !== "Column") {
+            return "";
+        }
+
+        return "-{$where["boolean"]}_{$where["first"]}_{$where["operator"]}_{$where["second"]}";
+    }
+
+    protected function getCurrentBinding(string $type, string $bindingFallback): string
+    {
+        return data_get($this->query->bindings, "{$type}.{$this->currentBinding}", $bindingFallback);
+    }
+
     protected function getIdColumn(string $idColumn) : string
     {
         return $idColumn ? "_{$idColumn}" : "";
+    }
+
+    protected function getInAndNotInClauses(array $where) : string
+    {
+        if (! in_array($where["type"], ["In", "NotIn", "InRaw"])) {
+            return "";
+        }
+
+        $type = strtolower($where["type"]);
+        $subquery = $this->getValuesFromWhere($where);
+        $values = collect($this->getCurrentBinding('where') ?? []);
+
+        if (Str::startsWith($subquery, $values->first())) {
+            $this->currentBinding += count($where["values"]);
+        }
+
+        if (! is_numeric($subquery) && ! is_numeric(str_replace("_", "", $subquery))) {
+            try {
+                $subquery = Uuid::fromBytes($subquery);
+                $values = $this->recursiveImplode([$subquery], "_");
+
+                return "-{$where["column"]}_{$type}{$values}";
+            } catch (Exception $exception) {
+                // do nothing
+            }
+        }
+
+        $subquery = preg_replace('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', "_??_", $subquery);
+        $subquery = collect(vsprintf(str_replace("_??_", "%s", $subquery), $values->toArray()));
+        $values = $this->recursiveImplode($subquery->toArray(), "_");
+
+        return "-{$where["column"]}_{$type}{$values}";
     }
 
     protected function getLimitClause() : string
@@ -67,15 +122,18 @@ class CacheKey
         return "-limit_{$this->query->limit}";
     }
 
-    protected function getTableSlug() : string
-    {
-        return (new Str)->slug($this->query->from)
-            . ":";
-    }
-
     protected function getModelSlug() : string
     {
         return (new Str)->slug(get_class($this->model));
+    }
+
+    protected function getNestedClauses(array $where) : string
+    {
+        if (! in_array($where["type"], ["Exists", "Nested", "NotExists"])) {
+            return "";
+        }
+
+        return "-" . strtolower($where["type"]) . $this->getWhereClauses($where["query"]->wheres);
     }
 
     protected function getOffsetClause() : string
@@ -110,6 +168,18 @@ class CacheKey
             ?: "";
     }
 
+    protected function getOtherClauses(array $where) : string
+    {
+        if (in_array($where["type"], ["Exists", "Nested", "NotExists", "Column", "raw", "In", "NotIn", "InRaw"])) {
+            return "";
+        }
+
+        $value = $this->getTypeClause($where);
+        $value .= $this->getValuesClause($where);
+
+        return "-{$where["column"]}_{$value}";
+    }
+
     protected function getQueryColumns(array $columns) : string
     {
         if (($columns === ["*"]
@@ -127,6 +197,36 @@ class CacheKey
         }
 
         return "_" . implode("_", $columns);
+    }
+
+    protected function getRawClauses(array $where) : string
+    {
+        if (! in_array($where["type"], ["raw"])) {
+            return "";
+        }
+
+        $queryParts = explode("?", $where["sql"]);
+        $clause = "_{$where["boolean"]}";
+
+        while (count($queryParts) > 1) {
+            $clause .= "_" . array_shift($queryParts);
+            $clause .= $this->getCurrentBinding('where');
+            $this->currentBinding++;
+        }
+
+        $lastPart = array_shift($queryParts);
+
+        if ($lastPart) {
+            $clause .= "_" . $lastPart;
+        }
+
+        return "-" . str_replace(" ", "_", $clause);
+    }
+
+    protected function getTableSlug() : string
+    {
+        return (new Str)->slug($this->query->from)
+            . ":";
     }
 
     protected function getTypeClause($where) : string
@@ -174,9 +274,8 @@ class CacheKey
 
     protected function getValuesFromBindings(array $where, string $values) : string
     {
-        // Fallback to this when the current binding does not exist in the bindings array
         $bindingFallback = __CLASS__ . ':UNKNOWN_BINDING';
-        $currentBinding = $this->getCurrentBinding('where') ?? $bindingFallback;
+        $currentBinding = $this->getCurrentBinding('where', $bindingFallback);
 
         if ($currentBinding !== $bindingFallback) {
             $values = $currentBinding;
@@ -211,119 +310,7 @@ class CacheKey
                 return $value;
             });
     }
-
-    protected function getNestedClauses(array $where) : string
-    {
-        if (! in_array($where["type"], ["Exists", "Nested", "NotExists"])) {
-            return "";
-        }
-
-        return "-" . strtolower($where["type"]) . $this->getWhereClauses($where["query"]->wheres);
-    }
-
-    protected function getColumnClauses(array $where) : string
-    {
-        if ($where["type"] !== "Column") {
-            return "";
-        }
-
-        return "-{$where["boolean"]}_{$where["first"]}_{$where["operator"]}_{$where["second"]}";
-    }
-
-    protected function getInAndNotInClauses(array $where) : string
-    {
-        if (! in_array($where["type"], ["In", "NotIn", "InRaw"])) {
-            return "";
-        }
-
-        $type = strtolower($where["type"]);
-        $subquery = $this->getValuesFromWhere($where);
-        $values = collect($this->getCurrentBinding('where') ?? []);
-
-        if (Str::startsWith($subquery, $values->first())) {
-            $this->currentBinding += count($where["values"]);
-        }
-
-        if (! is_numeric($subquery) && ! is_numeric(str_replace("_", "", $subquery))) {
-            try {
-                $subquery = Uuid::fromBytes($subquery);
-                $values = $this->recursiveImplode([$subquery], "_");
-
-                return "-{$where["column"]}_{$type}{$values}";
-            } catch (Exception $exception) {
-                // do nothing
-            }
-        }
-
-        $subquery = preg_replace('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', "_??_", $subquery);
-        $subquery = collect(vsprintf(str_replace("_??_", "%s", $subquery), $values->toArray()));
-        $values = $this->recursiveImplode($subquery->toArray(), "_");
-
-        return "-{$where["column"]}_{$type}{$values}";
-    }
-
-    protected function recursiveImplode(array $items, string $glue = ",") : string
-    {
-        $result = "";
-
-        foreach ($items as $value) {
-            if (is_string($value)) {
-                $value = str_replace('"', '', $value);
-                $value = explode(" ", $value);
-
-                if (count($value) === 1) {
-                    $value = $value[0];
-                }
-            }
-
-            if (is_array($value)) {
-                $result .= $this->recursiveImplode($value, $glue);
-
-                continue;
-            }
-
-            $result .= $glue . $value;
-        }
-
-        return $result;
-    }
-
-    protected function getRawClauses(array $where) : string
-    {
-        if (! in_array($where["type"], ["raw"])) {
-            return "";
-        }
-
-        $queryParts = explode("?", $where["sql"]);
-        $clause = "_{$where["boolean"]}";
-
-        while (count($queryParts) > 1) {
-            $clause .= "_" . array_shift($queryParts);
-            $clause .= $this->getCurrentBinding('where');
-            $this->currentBinding++;
-        }
-
-        $lastPart = array_shift($queryParts);
-
-        if ($lastPart) {
-            $clause .= "_" . $lastPart;
-        }
-
-        return "-" . str_replace(" ", "_", $clause);
-    }
-
-    protected function getOtherClauses(array $where) : string
-    {
-        if (in_array($where["type"], ["Exists", "Nested", "NotExists", "Column", "raw", "In", "NotIn", "InRaw"])) {
-            return "";
-        }
-
-        $value = $this->getTypeClause($where);
-        $value .= $this->getValuesClause($where);
-
-        return "-{$where["column"]}_{$value}";
-    }
-
+    
     protected function getWheres(array $wheres) : Collection
     {
         $wheres = collect($wheres);
@@ -357,19 +344,30 @@ class CacheKey
             return "{$carry}-{$relatedConnection}:{$relatedDatabase}:{$related}";
         });
     }
-
-    protected function getBindingsSlug() : string
+   
+    protected function recursiveImplode(array $items, string $glue = ",") : string
     {
-        if (! method_exists($this->model, 'query')) {
-            return '';
+        $result = "";
+
+        foreach ($items as $value) {
+            if (is_string($value)) {
+                $value = str_replace('"', '', $value);
+                $value = explode(" ", $value);
+
+                if (count($value) === 1) {
+                    $value = $value[0];
+                }
+            }
+
+            if (is_array($value)) {
+                $result .= $this->recursiveImplode($value, $glue);
+
+                continue;
+            }
+
+            $result .= $glue . $value;
         }
 
-        return Arr::query($this->model->query()->getBindings());
-    }
-
-
-    private function getCurrentBinding(string $type)
-    {
-        return data_get($this->query->bindings, "$type.$this->currentBinding");
+        return $result;
     }
 }

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -174,7 +174,10 @@ class CacheKey
 
     protected function getValuesFromBindings(array $where, string $values) : string
     {
-        if (($this->query->bindings["where"][$this->currentBinding] ?? false) !== false) {
+        // Fallback to this when the current binding does not exist in the bindings array
+        $bindingFallback = __CLASS__ . ':UNKNOWN_BINDING';
+
+        if (($this->query->bindings["where"][$this->currentBinding] ?? $bindingFallback) !== $bindingFallback) {
             $values = $this->query->bindings["where"][$this->currentBinding];
             $this->currentBinding++;
 

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -87,7 +87,7 @@ class CacheKey
 
         $type = strtolower($where["type"]);
         $subquery = $this->getValuesFromWhere($where);
-        $values = collect($this->getCurrentBinding('where') ?? []);
+        $values = collect($this->getCurrentBinding('where', []));
 
         if (Str::startsWith($subquery, $values->first())) {
             $this->currentBinding += count($where["values"]);
@@ -210,7 +210,7 @@ class CacheKey
 
         while (count($queryParts) > 1) {
             $clause .= "_" . array_shift($queryParts);
-            $clause .= $this->getCurrentBinding('where');
+            $clause .= $this->getCurrentBinding("where", "");
             $this->currentBinding++;
         }
 
@@ -275,14 +275,14 @@ class CacheKey
     protected function getValuesFromBindings(array $where, string $values) : string
     {
         $bindingFallback = __CLASS__ . ':UNKNOWN_BINDING';
-        $currentBinding = $this->getCurrentBinding('where', $bindingFallback);
+        $currentBinding = $this->getCurrentBinding("where", $bindingFallback);
 
         if ($currentBinding !== $bindingFallback) {
             $values = $currentBinding;
             $this->currentBinding++;
 
             if ($where["type"] === "between") {
-                $values .= "_" . $this->getCurrentBinding('where');
+                $values .= "_" . $this->getCurrentBinding("where", "");
                 $this->currentBinding++;
             }
         }

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -69,7 +69,7 @@ class CacheKey
         return "-{$where["boolean"]}_{$where["first"]}_{$where["operator"]}_{$where["second"]}";
     }
 
-    protected function getCurrentBinding(string $type, mixed $bindingFallback = null): mixed
+    protected function getCurrentBinding(string $type, $bindingFallback = null)
     {
         return data_get($this->query->bindings, "{$type}.{$this->currentBinding}", $bindingFallback);
     }

--- a/tests/Integration/CachedBuilder/BooleanTest.php
+++ b/tests/Integration/CachedBuilder/BooleanTest.php
@@ -1,12 +1,14 @@
 <?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
 
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
 
 class BooleanTest extends IntegrationTestCase
 {
-    public function testBooleanWhereCreatesCorrectCacheKey()
+    public function testBooleanWhereTrueCreatesCorrectCacheKey()
     {
         $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-is_famous_=_1-authors.deleted_at_null");
         $tags = [
@@ -26,6 +28,63 @@ class BooleanTest extends IntegrationTestCase
         $this->assertEquals($liveResults->pluck("id"), $authors->pluck("id"));
         $this->assertEquals($liveResults->pluck("id"), $cachedResults->pluck("id"));
         $this->assertNotEmpty($authors);
+        $this->assertNotEmpty($cachedResults);
+        $this->assertNotEmpty($liveResults);
+    }
+
+    public function testBooleanWhereFalseCreatesCorrectCacheKey()
+    {
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-is_famous_=_-authors.deleted_at_null");
+        $tags = [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
+        ];
+
+        $authors = (new Author)
+            ->where("is_famous", false)
+            ->get();
+        $cachedResults = $this->cache()
+            ->tags($tags)
+            ->get($key)['value'];
+        $liveResults = (new UncachedAuthor)
+            ->where("is_famous", false)
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $authors->pluck("id"));
+        $this->assertEquals($liveResults->pluck("id"), $cachedResults->pluck("id"));
+        $this->assertNotEmpty($authors);
+        $this->assertNotEmpty($cachedResults);
+        $this->assertNotEmpty($liveResults);
+    }
+
+    public function testBooleanWhereHasRelationWithFalseConditionAndAdditionalParentRawCondition()
+    {
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-and_books.author_id_=_authors.id-is_famous_=_-authors.deleted_at_null-_and_title_=_Mixed_Clause");
+        $tags = [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
+        ];
+
+        $expectedAuthor = factory(Author::class)->create(['is_famous' => false]);
+        factory(Book::class)->create(['author_id' => $expectedAuthor->getKey(), 'title' => 'Mixed Clause']);
+
+        $books = (new Book)
+            ->whereHas('author', function ($query) {
+                return $query->where('is_famous', false);
+            })
+            ->whereRaw("title = ?", ['Mixed Clause']) // Test ensures this binding is included in the key
+            ->get();
+        $cachedResults = $this->cache()
+            ->tags($tags)
+            ->get($key)['value'];
+        $liveResults = (new UncachedBook)
+            ->whereHas('author', function ($query) {
+                return $query->where('is_famous', false);
+            })
+            ->whereRaw("title = ?", ['Mixed Clause'])
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+        $this->assertEquals($liveResults->pluck("id"), $cachedResults->pluck("id"));
+        $this->assertNotEmpty($books);
         $this->assertNotEmpty($cachedResults);
         $this->assertNotEmpty($liveResults);
     }

--- a/tests/Integration/CachedBuilder/PolymorphicOneToManyTest.php
+++ b/tests/Integration/CachedBuilder/PolymorphicOneToManyTest.php
@@ -37,7 +37,7 @@ class PolymorphicOneToManyTest extends IntegrationTestCase
 
     public function testLazyloadedRelationship()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-comments.commentable_id_=_1-comments.commentable_id_notnull-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-comments.commentable_id_=_1-comments.commentable_id_notnull");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturescomment",
         ];

--- a/tests/Integration/CachedBuilder/PolymorphicOneToOneTest.php
+++ b/tests/Integration/CachedBuilder/PolymorphicOneToOneTest.php
@@ -37,7 +37,7 @@ class PolymorphicOneToOneTest extends IntegrationTestCase
 
     public function testLazyloadedHasOneThrough()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:images:genealabslaravelmodelcachingtestsfixturesimage-images.imagable_id_=_2-images.imagable_id_notnull-images.imagable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\User-limit_1");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:images:genealabslaravelmodelcachingtestsfixturesimage-images.imagable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\User-images.imagable_id_=_2-images.imagable_id_notnull-limit_1");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesimage",
         ];


### PR DESCRIPTION
This bug is difficult to explain clearly so I will try my best.

I discovered it when I was trying query where a relation had a false column then using a `whereRaw` after. See this example below from the added test in this PR:

```php
$books = (new Book)
    ->whereHas('author', function ($query) {
        return $query->where('is_famous', false); // Passing false here is the issue
    })
    ->whereRaw("title = ?", ['Mixed Clause']) // This binding ends up not being included in the cache key
    ->get();
```

**Issue**
Before this PR fix the cache key that is generated would be missing the 'Mixed Clause' binding see below where the key ends without the value. 

```
-exists-and_books.author_id_=_authors.id-is_famous_=_-authors.deleted_at_null-_and_title_=
```

**Workaround**
If you use zero instead as the value `$query->where('is_famous', 0)` the key is generated correctly.

**Cause**
This is caused by false bindings being ignored in `CacheKey::getValuesFromBindings` and the `currentBindings` count was therefore not being incremented correctly. 

```php
protected function getValuesFromBindings(array $where, string $values) : string
{
    // If this array value is false then the binding is ignored
    if (($this->query->bindings["where"][$this->currentBinding] ?? false) !== false) {
        // ...
        $this-currentBinding++;
        // ...
```

**Fix**
Rather than `CacheKey::getValuesFromBindings` comparing using false it should use some specific value to compare with so it only skips if the binding is not set. Feel free to feedback on this but its a necessary evil to have some sort of unique string provided that is unlikely to be passed as a field value. 

```php
protected function getValuesFromBindings(array $where, string $values) : string
{
    // Fallback to this when the current binding does not exist in the bindings array
    $bindingFallback = __CLASS__ . ':UNKNOWN_BINDING';
    
    if (($this->query->bindings["where"][$this->currentBinding] ??  $bindingFallback) !==  $bindingFallback) {
``` 

And this ensures that the generated cache key contains all the correct bindings:
```
-exists-and_books.author_id_=_authors.id-is_famous_=_-authors.deleted_at_null-_and_title_=_Mixed_Clause
```

**Potential Additional Change?**
Not sure if you noticed but when the value is `false` the generated cache key inserts the `false` as an empty string `-is_famous_=_-` . 

I wonder if we should detect `false` values and make the key insert them as `0` or `'false'` string, e.g. `-is_famous_=_0- ` or `is_famous_=_false-`?