### PR TITLE
Support for full text search

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -177,7 +177,11 @@ class CacheKey
         $value = $this->getTypeClause($where);
         $value .= $this->getValuesClause($where);
 
-        return "-{$where["column"]}_{$value}";
+        $column = "";
+        $column .= isset($where["column"]) ? $where["column"] : "";
+        $column .= isset($where["columns"]) ? implode("-", $where["columns"]) : "";
+
+        return "-{$column}_{$value}";
     }
 
     protected function getQueryColumns(array $columns) : string
@@ -231,7 +235,7 @@ class CacheKey
 
     protected function getTypeClause($where) : string
     {
-        $type = in_array($where["type"], ["InRaw", "In", "NotIn", "Null", "NotNull", "between", "NotInSub", "InSub", "JsonContains"])
+        $type = in_array($where["type"], ["InRaw", "In", "NotIn", "Null", "NotNull", "between", "NotInSub", "InSub", "JsonContains", "Fulltext"])
             ? strtolower($where["type"])
             : strtolower($where["operator"]);
 


### PR DESCRIPTION
Recently Laravel added support for full-text search where clauses in the query builder. 
https://laravel.com/docs/9.x/queries#full-text-where-clauses

Looks like using that functionality with this package throws an error in line 240 of CacheKey.php because it didn't properly handle that where clause. 

This pull request makes a few changes to support full-text where clauses.