### PR TITLE
Add support for withoutGlobalScopes

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -63,7 +63,11 @@ class CacheKey
             return '';
         }
 
-        if ($this->withoutAllScopes || ($this->withoutScopes != null && count($this->withoutScopes) == 0)) {
+        if ($this->withoutAllScopes) {
+            return Arr::query($this->model->query()->withoutGlobalScopes()->getBindings());
+        }
+
+        if (count($this->withoutScopes) > 0) {
             return Arr::query($this->model->query()->withoutGlobalScopes($this->withoutScopes)->getBindings());
         }
 

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -16,17 +16,23 @@ class CacheKey
     protected $macroKey;
     protected $model;
     protected $query;
+    protected $withoutScopes = [];
+    protected $withoutAllScopes = false;
 
     public function __construct(
         array $eagerLoad,
         $model,
         $query,
-        $macroKey
+        $macroKey,
+        $withoutScopes,
+        $withoutAllScopes
     ) {
         $this->eagerLoad = $eagerLoad;
         $this->macroKey = $macroKey;
         $this->model = $model;
         $this->query = $query;
+        $this->withoutScopes = $withoutScopes;
+        $this->withoutAllScopes = $withoutAllScopes;
     }
 
     public function make(
@@ -55,6 +61,10 @@ class CacheKey
     {
         if (! method_exists($this->model, 'query')) {
             return '';
+        }
+
+        if ($this->withoutAllScopes || ($this->withoutScopes != null && count($this->withoutScopes) == 0)) {
+            return Arr::query($this->model->query()->withoutGlobalScopes($this->withoutScopes)->getBindings());
         }
 
         return Arr::query($this->model->query()->getBindings());

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -24,7 +24,7 @@ class CacheKey
         $model,
         $query,
         $macroKey,
-        $withoutScopes,
+        array $withoutScopes,
         $withoutAllScopes
     ) {
         $this->eagerLoad = $eagerLoad;

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -16,23 +16,23 @@ class CacheKey
     protected $macroKey;
     protected $model;
     protected $query;
-    protected $withoutScopes = [];
-    protected $withoutAllScopes = false;
+    protected $withoutGlobalScopes = [];
+    protected $withoutAllGlobalScopes = false;
 
     public function __construct(
         array $eagerLoad,
         $model,
         $query,
         $macroKey,
-        array $withoutScopes,
-        $withoutAllScopes
+        array $withoutGlobalScopes,
+        $withoutAllGlobalScopes
     ) {
         $this->eagerLoad = $eagerLoad;
         $this->macroKey = $macroKey;
         $this->model = $model;
         $this->query = $query;
-        $this->withoutScopes = $withoutScopes;
-        $this->withoutAllScopes = $withoutAllScopes;
+        $this->withoutGlobalScopes = $withoutGlobalScopes;
+        $this->withoutAllGlobalScopes = $withoutAllGlobalScopes;
     }
 
     public function make(
@@ -63,12 +63,12 @@ class CacheKey
             return '';
         }
 
-        if ($this->withoutAllScopes) {
+        if ($this->withoutAllGlobalScopes) {
             return Arr::query($this->model->query()->withoutGlobalScopes()->getBindings());
         }
 
-        if (count($this->withoutScopes) > 0) {
-            return Arr::query($this->model->query()->withoutGlobalScopes($this->withoutScopes)->getBindings());
+        if (count($this->withoutGlobalScopes) > 0) {
+            return Arr::query($this->model->query()->withoutGlobalScopes($this->withoutGlobalScopes)->getBindings());
         }
 
         return Arr::query($this->model->query()->getBindings());

--- a/src/Traits/BuilderCaching.php
+++ b/src/Traits/BuilderCaching.php
@@ -24,7 +24,7 @@ trait BuilderCaching
 
     public function withoutGlobalScope($scope)
     {
-        array_push($this->withoutScopes, $scope);
+        array_push($this->withoutGlobalScopes, $scope);
 
         return parent::withoutGlobalScope($scope);
     }
@@ -32,11 +32,11 @@ trait BuilderCaching
     public function withoutGlobalScopes(array $scopes = null)
     {
         if ($scopes != null) {
-            $this->withoutScopes = $scopes;
+            $this->withoutGlobalScopes = $scopes;
         }
 
         if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
-            $this->withoutAllScopes = true;
+            $this->withoutAllGlobalScopes = true;
         }
 
         return parent::withoutGlobalScopes($scopes);

--- a/src/Traits/BuilderCaching.php
+++ b/src/Traits/BuilderCaching.php
@@ -21,4 +21,16 @@ trait BuilderCaching
 
         return parent::truncate();
     }
+
+    public function withoutGlobalScopes(array $scopes = null)
+    {
+        $this->scopesAreApplied = true;
+        $this->withoutScopes = $scopes;
+
+        if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
+            $this->withoutAllScopes = true;
+        }
+
+        return parent::withoutGlobalScopes($scopes);
+    }
 }

--- a/src/Traits/BuilderCaching.php
+++ b/src/Traits/BuilderCaching.php
@@ -21,4 +21,27 @@ trait BuilderCaching
 
         return parent::truncate();
     }
+
+    public function withoutGlobalScope($scope)
+    {
+        if ($this->withoutScopes == null) {
+            $this->withoutScopes = [];
+        }
+
+        array_push($this->withoutScopes, $scope);
+
+        return parent::withoutGlobalScope($scope);
+    }
+
+    public function withoutGlobalScopes(array $scopes = null)
+    {
+        $this->withoutScopes = $scopes;
+
+        if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
+            $this->withoutAllScopes = true;
+        }
+
+        return parent::withoutGlobalScopes($scopes);
+    }
+
 }

--- a/src/Traits/BuilderCaching.php
+++ b/src/Traits/BuilderCaching.php
@@ -24,10 +24,6 @@ trait BuilderCaching
 
     public function withoutGlobalScope($scope)
     {
-        if ($this->withoutScopes == null) {
-            $this->withoutScopes = [];
-        }
-
         array_push($this->withoutScopes, $scope);
 
         return parent::withoutGlobalScope($scope);
@@ -35,7 +31,9 @@ trait BuilderCaching
 
     public function withoutGlobalScopes(array $scopes = null)
     {
-        $this->withoutScopes = $scopes;
+        if ($scopes != null) {
+            $this->withoutScopes = $scopes;
+        }
 
         if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
             $this->withoutAllScopes = true;

--- a/src/Traits/BuilderCaching.php
+++ b/src/Traits/BuilderCaching.php
@@ -21,16 +21,4 @@ trait BuilderCaching
 
         return parent::truncate();
     }
-
-    public function withoutGlobalScopes(array $scopes = null)
-    {
-        $this->scopesAreApplied = true;
-        $this->withoutScopes = $scopes;
-
-        if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
-            $this->withoutAllScopes = true;
-        }
-
-        return parent::withoutGlobalScopes($scopes);
-    }
 }

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -16,8 +16,8 @@ trait Caching
     protected $isCachable = true;
     protected $scopesAreApplied = false;
     protected $macroKey = "";
-    protected $withoutScopes = [];
-    protected $withoutAllScopes = false;
+    protected $withoutGlobalScopes = [];
+    protected $withoutAllGlobalScopes = false;
 
     public function __call($method, $parameters)
     {
@@ -47,13 +47,13 @@ trait Caching
     {
         if (! property_exists($this, "scopes")
             || $this->scopesAreApplied
-            || $this->withoutAllScopes
+            || $this->withoutAllGlobalScopes
         ) {
             return;
         }
 
         foreach ($this->scopes as $identifier => $scope) {
-            if (! isset($this->scopes[$identifier]) || isset($this->withoutScopes[$identifier])) {
+            if (! isset($this->scopes[$identifier]) || isset($this->withoutGlobalScopes[$identifier])) {
                 continue;
             }
 
@@ -169,7 +169,7 @@ trait Caching
             $query = $this->query->getQuery();
         }
 
-        return (new CacheKey($eagerLoad, $model, $query, $this->macroKey, $this->withoutScopes, $this->withoutAllScopes))
+        return (new CacheKey($eagerLoad, $model, $query, $this->macroKey, $this->withoutGlobalScopes, $this->withoutAllGlobalScopes))
             ->make($columns, $idColumn, $keyDifferentiator);
     }
 

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -16,6 +16,8 @@ trait Caching
     protected $isCachable = true;
     protected $scopesAreApplied = false;
     protected $macroKey = "";
+    protected $withoutScopes = null;
+    protected $withoutAllScopes = false;
 
     public function __call($method, $parameters)
     {
@@ -166,7 +168,7 @@ trait Caching
             $query = $this->query->getQuery();
         }
 
-        return (new CacheKey($eagerLoad, $model, $query, $this->macroKey))
+        return (new CacheKey($eagerLoad, $model, $query, $this->macroKey, $this->withoutScopes, $this->withoutAllScopes))
             ->make($columns, $idColumn, $keyDifferentiator);
     }
 

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -16,7 +16,7 @@ trait Caching
     protected $isCachable = true;
     protected $scopesAreApplied = false;
     protected $macroKey = "";
-    protected $withoutScopes = null;
+    protected $withoutScopes = [];
     protected $withoutAllScopes = false;
 
     public function __call($method, $parameters)

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -43,41 +43,17 @@ trait Caching
         return parent::applyScopes();
     }
 
-    public function withoutGlobalScope($scope)
-    {
-        $this->scopesAreApplied = true;
-        if ($this->withoutScopes == null) {
-            $this->withoutScopes = [];
-        }
-
-        array_push($this->withoutScopes[], $scope);
-        $this->withoutAllScopes = false;
-
-        return parent::withoutGlobalScope($scope);
-    }
-
-    public function withoutGlobalScopes(array $scopes = null)
-    {
-        $this->scopesAreApplied = true;
-        $this->withoutScopes = $scopes;
-
-        if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
-            $this->withoutAllScopes = true;
-        }
-
-        return parent::withoutGlobalScopes($scopes);
-    }
-
     protected function applyScopesToInstance()
     {
         if (! property_exists($this, "scopes")
             || $this->scopesAreApplied
+            || $this->withoutAllScopes
         ) {
             return;
         }
 
         foreach ($this->scopes as $identifier => $scope) {
-            if (! isset($this->scopes[$identifier])) {
+            if (! isset($this->scopes[$identifier]) || isset($this->withoutScopes[$identifier])) {
                 continue;
             }
 

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -43,6 +43,31 @@ trait Caching
         return parent::applyScopes();
     }
 
+    public function withoutGlobalScope($scope)
+    {
+        $this->scopesAreApplied = true;
+        if ($this->withoutScopes == null) {
+            $this->withoutScopes = [];
+        }
+
+        array_push($this->withoutScopes[], $scope);
+        $this->withoutAllScopes = false;
+
+        return parent::withoutGlobalScope($scope);
+    }
+
+    public function withoutGlobalScopes(array $scopes = null)
+    {
+        $this->scopesAreApplied = true;
+        $this->withoutScopes = $scopes;
+
+        if ($scopes == null || ($scopes != null && count($scopes) == 0)) {
+            $this->withoutAllScopes = true;
+        }
+
+        return parent::withoutGlobalScopes($scopes);
+    }
+
     protected function applyScopesToInstance()
     {
         if (! property_exists($this, "scopes")

--- a/tests/Integration/CachedBuilder/ScopeTest.php
+++ b/tests/Integration/CachedBuilder/ScopeTest.php
@@ -156,6 +156,32 @@ class ScopeTest extends IntegrationTestCase
         $this->assertEquals("B", $authorsB->first());
     }
 
+    public function testWithoutGlobalScopes()
+    {
+        factory(Author::class, 200)->create();
+        $user = factory(User::class)->create(["name" => "Andrew Junior"]);
+        $this->actingAs($user);
+        $authorsA = (new AuthorBeginsWithScoped)
+            ->withoutGlobalScopes()
+            ->get()
+            ->map(function ($author) {
+                return (new Str)->substr($author->name, 0, 1);
+            })
+            ->unique();
+        $user = factory(User::class)->create(["name" => "Barry Barry Barry"]);
+        $this->actingAs($user);
+        $authorsB = (new AuthorBeginsWithScoped)
+            ->withoutGlobalScopes()
+            ->get()
+            ->map(function ($author) {
+                return (new Str)->substr($author->name, 0, 1);
+            })
+            ->unique();
+
+        $this->assertGreaterThan(1, count($authorsA));
+        $this->assertGreaterThan(1, count($authorsB));
+    }
+
     public function testLocalScopesInRelationship()
     {
         $first = "A";

--- a/tests/Integration/CachedBuilder/ScopeTest.php
+++ b/tests/Integration/CachedBuilder/ScopeTest.php
@@ -171,7 +171,33 @@ class ScopeTest extends IntegrationTestCase
         $user = factory(User::class)->create(["name" => "Barry Barry Barry"]);
         $this->actingAs($user);
         $authorsB = (new AuthorBeginsWithScoped)
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes(['GeneaLabs\LaravelModelCaching\Tests\Fixtures\Scopes\NameBeginsWith'])
+            ->get()
+            ->map(function ($author) {
+                return (new Str)->substr($author->name, 0, 1);
+            })
+            ->unique();
+
+        $this->assertGreaterThan(1, count($authorsA));
+        $this->assertGreaterThan(1, count($authorsB));
+    }
+
+    public function testWithoutGlobalScope()
+    {
+        factory(Author::class, 200)->create();
+        $user = factory(User::class)->create(["name" => "Andrew Junior"]);
+        $this->actingAs($user);
+        $authorsA = (new AuthorBeginsWithScoped)
+            ->withoutGlobalScope('GeneaLabs\LaravelModelCaching\Tests\Fixtures\Scopes\NameBeginsWith')
+            ->get()
+            ->map(function ($author) {
+                return (new Str)->substr($author->name, 0, 1);
+            })
+            ->unique();
+        $user = factory(User::class)->create(["name" => "Barry Barry Barry"]);
+        $this->actingAs($user);
+        $authorsB = (new AuthorBeginsWithScoped)
+            ->withoutGlobalScope('GeneaLabs\LaravelModelCaching\Tests\Fixtures\Scopes\NameBeginsWith')
             ->get()
             ->map(function ($author) {
                 return (new Str)->substr($author->name, 0, 1);


### PR DESCRIPTION
The intention of this PR is to add in support for the `withoutGlobalScope` and `withoutGlobalScopes` function in Eloquent (https://laravel.com/docs/8.x/eloquent#removing-global-scopes).

When an application using the Caching Library applies the `withoutGlobalScopes()` modifier to a model, the global scopes are currently being added back in by the Caching Library.  This requires the client application to disable the cache, `disableCache()`, prior to calling `withoutGlobalScopes`. This PR should fix that. 