### PR TITLE
add enum check when fetching values from where statements, fixes #426

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -287,7 +287,15 @@ class CacheKey
             return implode("_", collect($where["value"])->flatten()->toArray());
         }
 
-        return (new Arr)->get($where, "value", "");
+        $value = (new Arr)->get($where, "value", "");
+
+        if ($value instanceof \BackedEnum) {
+            return $value->value;
+        } elseif ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
+        return $value;
     }
 
     protected function getValuesFromBindings(array $where, string $values) : string


### PR DESCRIPTION
To allow enum values in queries, I have added an enum check in `getValuesFromWhere`.

If the enum is a backed enum, we return it's value, otherwise we return it's name.

This fixes issue #426