### PR TITLE
Add pivotSynced event listener to flush cache when performing BelongsToMany::sync

### DIFF
--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -75,6 +75,10 @@ trait ModelCaching
         //     $instance->checkCooldownAndFlushAfterPersisting($instance);
         // });
 
+        static::pivotSynced(function ($instance, $secondInstance, $relationship) {
+            $instance->checkCooldownAndFlushAfterPersisting($instance, $relationship);
+        });
+
         static::pivotAttached(function ($instance, $secondInstance, $relationship) {
             $instance->checkCooldownAndFlushAfterPersisting($instance, $relationship);
         });


### PR DESCRIPTION
As title describes, we've multiple issues on our Laravel 9 based project when users saving stuff on our API.

Apparently this "stuff" has all to do with using sync (in multiple cases required for our business logic to work with the feature design).

So that's how I've found that the **`pivotSynced` event was already available in laravel-pivot-events but not mentioned here**.

I'll later today send some commits verifying / testing this scenario I had