### PR TITLE
Customisable caching time

### DIFF
--- a/config/laravel-model-caching.php
+++ b/config/laravel-model-caching.php
@@ -8,4 +8,6 @@ return [
     'use-database-keying' => env('MODEL_CACHE_USE_DATABASE_KEYING', true),
 
     'store' => env('MODEL_CACHE_STORE'),
+
+    'caching_time' => (integer) env('MODEL_CACHE_TIME'),
 ];

--- a/src/Console/Commands/Clear.php
+++ b/src/Console/Commands/Clear.php
@@ -38,6 +38,10 @@ class Clear extends Command
 
     protected function flushModelCache(string $option) : int
     {
+        if (substr($option, 0, 9) == 'AppModels') {
+          $option = 'App\Models\\' . substr($option, 9);
+        }
+
         $model = new $option;
         $usesCachableTrait = $this->getAllTraitsUsedByClass($option)
             ->contains("GeneaLabs\LaravelModelCaching\Traits\Cachable");

--- a/src/Traits/Buildable.php
+++ b/src/Traits/Buildable.php
@@ -292,6 +292,22 @@ trait Buildable
             $this->checkCooldownAndRemoveIfExpired($this->getModel());
         }
 
+        $seconds = $this->getCachingTime();
+
+        if ($seconds > 0) {
+          return $this->cache($cacheTags)
+          ->remember(
+              $hashedCacheKey,
+              $seconds,
+              function () use ($arguments, $cacheKey, $method) {
+                  return [
+                      "key" => $cacheKey,
+                      "value" => parent::{$method}(...$arguments),
+                  ];
+              }
+          );
+        }
+
         return $this->cache($cacheTags)
             ->rememberForever(
                 $hashedCacheKey,


### PR DESCRIPTION
This pull request adds two changes:

-  Fixed resolving model in `flushModelCache` method (because of `Class "AppModelCountry" not found` error)
-  Added an option to configure caching time
   - to use for all models (global) - in config file
   - to use per model - in `$caching_time` variable on each model

We can configure `caching_time` in config file or in `.env` file (`MODEL_CACHE_TIME`). If it's provided caching would use `remember`  instead of `rememberForever`.

Or we can add `public $caching_time = 10;` property on model.

```php
use GeneaLabs\LaravelModelCaching\Traits\Cachable;

class Country extends Model
{
    use HasFactory, Cachable;

    /** @var integer */
    public $caching_time = 7;

```
