### PR TITLE
Make Buildable@paginate compatible with Laravel 10.3.0

### DIFF
--- a/src/Traits/Buildable.php
+++ b/src/Traits/Buildable.php
@@ -158,7 +158,8 @@ trait Buildable
         $perPage = null,
         $columns = ["*"],
         $pageName = "page",
-        $page = null
+        $page = null,
+        $total = null
     ) {
         if (! $this->isCachable()) {
             return parent::paginate($perPage, $columns, $pageName, $page);
@@ -170,7 +171,17 @@ trait Buildable
             $page = $this->recursiveImplodeWithKey($page);
         }
         $columns = collect($columns)->toArray();
-        $cacheKey = $this->makeCacheKey($columns, null, "-paginate_by_{$perPage}_{$pageName}_{$page}");
+
+        $keyDifferentiator = "-paginate_by_{$perPage}_{$pageName}_{$page}";
+
+        if ($total !== null) {
+            $total = value($total);
+            if ($total !== null) {
+                $keyDifferentiator .= "_{$total}";
+            }
+        }
+
+        $cacheKey = $this->makeCacheKey($columns, null, $keyDifferentiator);
 
         return $this->cachedValue(func_get_args(), $cacheKey);
     }

--- a/src/Traits/Buildable.php
+++ b/src/Traits/Buildable.php
@@ -170,15 +170,15 @@ trait Buildable
         if (is_array($page)) {
             $page = $this->recursiveImplodeWithKey($page);
         }
+        
         $columns = collect($columns)->toArray();
-
         $keyDifferentiator = "-paginate_by_{$perPage}_{$pageName}_{$page}";
 
         if ($total !== null) {
             $total = value($total);
-            if ($total !== null) {
-                $keyDifferentiator .= "_{$total}";
-            }
+            $keyDifferentiator .= $total !== null
+                ? "_{$total}"
+                : "";
         }
 
         $cacheKey = $this->makeCacheKey($columns, null, $keyDifferentiator);


### PR DESCRIPTION
Fixes the issue referenced in #445. Laravel 10.3.0 added a `$total` parameter to `Illuminate\Database\Eloquent\Builder::paginate`. This PR adds the same parameter to `GeneaLabs\LaravelModelCaching\Traits\Buildable::paginate` to eliminate PHP errors about a mismatch in function signature.