### PR TITLE
parsing of second if it is an Expression object

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -85,6 +85,10 @@ class CacheKey
             $where["first"] = $this->expressionToString($where["first"]);
         }
         
+		if ($where["second"] instanceof Expression) {
+			$where["second"] = $this->expressionToString($where["second"]);
+		}
+        
         return "-{$where["boolean"]}_{$where["first"]}_{$where["operator"]}_{$where["second"]}";
     }
 


### PR DESCRIPTION
```php
array:5 [ // vendor/genealabs/laravel-model-caching/src/CacheKey.php:90
  "type" => "Column"
  "first" => "subscription_features.id"
  "operator" => "="
  "second" => Illuminate\Database\Query\Expression {#1951
    #value: ""subscription_plans"."feature_id""
  }
  "boolean" => "and"
]
```


@mikebronner please review & merge this