### PR TITLE
fix: GeneaLabs/laravel-model-caching issue #448

### DIFF
--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -75,19 +75,19 @@ trait ModelCaching
         //     $instance->checkCooldownAndFlushAfterPersisting($instance);
         // });
 
-        static::pivotSynced(function ($instance, $secondInstance, $relationship) {
+        static::pivotSynced(function ($instance, $relationship) {
             $instance->checkCooldownAndFlushAfterPersisting($instance, $relationship);
         });
 
-        static::pivotAttached(function ($instance, $secondInstance, $relationship) {
+        static::pivotAttached(function ($instance, $relationship) {
             $instance->checkCooldownAndFlushAfterPersisting($instance, $relationship);
         });
 
-        static::pivotDetached(function ($instance, $secondInstance, $relationship) {
+        static::pivotDetached(function ($instance, $relationship) {
             $instance->checkCooldownAndFlushAfterPersisting($instance, $relationship);
         });
 
-        static::pivotUpdated(function ($instance, $secondInstance, $relationship) {
+        static::pivotUpdated(function ($instance, $relationship) {
             $instance->checkCooldownAndFlushAfterPersisting($instance, $relationship);
         });
     }


### PR DESCRIPTION
This patch resolved an error we were receiving when using attach() or detach() on a Model relationship after upgrading to Laravel 10. This patch seems to fix a bug introduced by this commit: https://github.com/GeneaLabs/laravel-pivot-events/commit/862371f6f89be296cc026c9cf5b372dca4d7958b

Relevant package versions:

```
laravel/framework: 10.4.1
genealabs/laravel-model-caching: 0.13.3
genealabs/laravel-pivot-events: 10.0.1
```

We were receiving the same error described in issue #448:

```
checkCooldownAndFlushAfterPersisting(): Argument # 2 ($relationship) must be of type string, array given, called in /var/www/html/vendor/genealabs/laravel-model-caching/src/Traits/ModelCaching.php on line 83
```

Prior to this patch, I confirmed Argument # 2 ($relationship) contained an array of record IDs. After this patch, I confirmed Argument # 2 ($relationship) contained a string with the relationship name. The Model cache appears to be updated as expected after attach() and detach() events.

**I was unable to run the package's test suite.** This package seems to require Laravel Nova? I do not have a Nova license. Running `composer install` within this package directory prompts for a Laravel Nova login.