### PR TITLE
Allow using custom builders on models

### DIFF
--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -111,7 +111,7 @@ trait ModelCaching
         if (! $this->isCachable()) {
             $this->isCachable = false;
 
-            return new EloquentBuilder($query);
+            return parent::newEloquentBuilder($query);
         }
 
         return new CachedBuilder($query);


### PR DESCRIPTION
Use original model newEloquentBuilder to retrieve the builder used for a model.
This allows using custom builders on models, defining them with UseEloquentBuilder attribute or $builder static property