### PR TITLE
fix: escape % in whereIn values before passing to vsprintf (#516)

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -154,6 +154,7 @@ class CacheKey
         }
 
         $subquery = preg_replace('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', "_??_", $subquery);
+        $subquery = str_replace('%', '%%', $subquery);
         $subquery = collect(vsprintf(str_replace("_??_", "%s", $subquery), $values->toArray()));
         $values = $this->recursiveImplode($subquery->toArray(), "_");
 

--- a/tests/Integration/CachedBuilder/WhereInTest.php
+++ b/tests/Integration/CachedBuilder/WhereInTest.php
@@ -99,4 +99,26 @@ class WhereInTest extends IntegrationTestCase
         $this->assertEmpty($authors->diffKeys($cachedResults));
         $this->assertEmpty($liveResults->diffKeys($cachedResults));
     }
+
+    public function testWhereInWithPercentCharacterInValueDoesNotThrow()
+    {
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_in_10%_20%-authors.deleted_at_null");
+        $tags = [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
+        ];
+
+        $authors = (new Author)
+            ->whereIn('name', ['10%', '20%'])
+            ->get();
+        $cachedResults = $this
+            ->cache()
+            ->tags($tags)
+            ->get($key)['value'];
+        $liveResults = (new UncachedAuthor)
+            ->whereIn('name', ['10%', '20%'])
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $authors->pluck("id"));
+        $this->assertEquals($liveResults->pluck("id"), $cachedResults->pluck("id"));
+    }
 }


### PR DESCRIPTION
## What

Fixes a `ValueError: Missing format specifier at end of string` crash when using `whereIn` (or `whereNotIn`) with values that contain `%` characters (e.g. `['10%', '20%']`).

## Why

In `CacheKey::getInAndNotInClauses()`, the cache key is built by substituting values into a format string using `vsprintf()`. A literal `%` in a query value gets misread by `vsprintf` as the start of a format specifier, triggering:

```
ValueError: Missing format specifier at end of string
```

Stack trace from the reporter:
```
#0 vendor/genealabs/laravel-model-caching/src/CacheKey.php(157): vsprintf('A--10%', Array)
```

## How

One-line fix: after replacing `?` placeholders with `_??_` and before the final `str_replace("_??_", "%s", ...)` + `vsprintf` call, escape any literal `%` in `$subquery` to `%%`:

```php
 = str_replace('%', '%%', $subquery);
```

**Order matters:**
1. `preg_replace` turns `?` → `_??_` (no `%` involved)
2. `str_replace('%', '%%', ...)` escapes literal `%` from user values
3. `str_replace('_??_', '%s', ...)` creates the actual format specifiers
4. `vsprintf()` sees `%%` as literal `%` and `%s` as placeholders — correct

This is safe for all other `whereIn` usage: values without `%` are unaffected, and values that go through normal binding substitution still work correctly.

## How to test

```php
// Before fix: throws ValueError
// After fix: works correctly
CachedModel::query()->whereIn('value', ['10%', '20%'])->get();
```

Added regression test: `WhereInTest::testWhereInWithPercentCharacterInValueDoesNotThrow`

Closes #516