### PR TITLE
test(auth): Added belongsToMany caching tests for Authenticatable+Cachable model

### DIFF
--- a/tests/Fixtures/Role.php
+++ b/tests/Fixtures/Role.php
@@ -1,0 +1,19 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use GeneaLabs\LaravelModelCaching\Traits\Cachable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    use Cachable;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function users() : BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+}

--- a/tests/Fixtures/UncachedRole.php
+++ b/tests/Fixtures/UncachedRole.php
@@ -1,0 +1,17 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class UncachedRole extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+    protected $table = 'roles';
+
+    public function users() : BelongsToMany
+    {
+        return $this->belongsToMany(UncachedUser::class, 'role_user', 'role_id', 'user_id');
+    }
+}

--- a/tests/Fixtures/UncachedUser.php
+++ b/tests/Fixtures/UncachedUser.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 class UncachedUser extends Model
@@ -11,6 +12,11 @@ class UncachedUser extends Model
         "supplier_id",
     ];
     protected $table = "users";
+
+    public function roles() : BelongsToMany
+    {
+        return $this->belongsToMany(UncachedRole::class, 'role_user', 'user_id', 'role_id');
+    }
 
     public function supplier() : BelongsTo
     {

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -4,6 +4,7 @@ use GeneaLabs\LaravelModelCaching\Traits\Cachable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -15,6 +16,11 @@ class User extends Authenticatable
         "name",
         "supplier_id",
     ];
+
+    public function roles() : BelongsToMany
+    {
+        return $this->belongsToMany(Role::class);
+    }
 
     public function supplier() : BelongsTo
     {

--- a/tests/Integration/CachedBuilder/AuthenticatableBelongsToManyTest.php
+++ b/tests/Integration/CachedBuilder/AuthenticatableBelongsToManyTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\CachedBelongsToMany;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Role;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedUser;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\User;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Covers the scenario from issue #473: an Authenticatable-based model using
+ * the Cachable trait should correctly cache belongsToMany relationships, with
+ * cache invalidation on attach / detach / sync.
+ */
+class AuthenticatableBelongsToManyTest extends IntegrationTestCase
+{
+    /**
+     * Return the id of a seeded user that has at least one role attached.
+     */
+    private function userIdWithRoles(): int
+    {
+        return (int) DB::table('role_user')->value('user_id');
+    }
+
+    /**
+     * Use reflection to get the actual cache tags and key from the relationship
+     * instance, so we're not hard-coding implementation details.
+     */
+    private function getCacheTagsAndKey(CachedBelongsToMany $relation): array
+    {
+        $reflTags = new \ReflectionMethod($relation, 'makeCacheTags');
+        $reflTags->setAccessible(true);
+        $tags = $reflTags->invoke($relation);
+
+        $reflKey = new \ReflectionMethod($relation, 'makeCacheKey');
+        $reflKey->setAccessible(true);
+        $rawKey = $reflKey->invoke($relation);
+
+        return [$tags, sha1($rawKey)];
+    }
+
+    // -------------------------------------------------------------------------
+    // Sanity check: the relationship returns the right class
+    // -------------------------------------------------------------------------
+
+    public function testRolesRelationshipReturnsCachedBelongsToMany(): void
+    {
+        $userId = $this->userIdWithRoles();
+        $relation = (new User)->find($userId)->roles();
+
+        $this->assertInstanceOf(
+            CachedBelongsToMany::class,
+            $relation,
+            'Expected roles() on an Authenticatable+Cachable model to return CachedBelongsToMany.'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // AC1: Query is cached
+    // -------------------------------------------------------------------------
+
+    public function testBelongsToManyOnAuthenticatableModelCachesResults(): void
+    {
+        $userId = $this->userIdWithRoles();
+
+        $relation = (new User)->find($userId)->roles();
+        [$tags, $hashedKey] = $this->getCacheTagsAndKey($relation);
+
+        // Access the relationship — this should warm the cache.
+        $roles = (new User)->find($userId)->roles;
+        $cachedResult = $this->cache()->tags($tags)->get($hashedKey);
+        $cachedRoles = $cachedResult['value'] ?? null;
+        $uncachedRoles = (new UncachedUser)->find($userId)->roles;
+
+        $this->assertNotNull($cachedRoles, 'Expected roles to be stored in cache, but cache was empty.');
+        $this->assertNotEmpty($roles);
+        $this->assertEquals($uncachedRoles->pluck('id'), $roles->pluck('id'));
+        $this->assertEquals($uncachedRoles->pluck('id'), $cachedRoles->pluck('id'));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC2a: Cache is invalidated on attach
+    // -------------------------------------------------------------------------
+
+    public function testCacheIsInvalidatedWhenAttachingRole(): void
+    {
+        $userId = $this->userIdWithRoles();
+
+        $relation = (new User)->find($userId)->roles();
+        [$tags, $hashedKey] = $this->getCacheTagsAndKey($relation);
+
+        // Warm the cache.
+        $result = (new User)->find($userId)->roles;
+        $this->assertNotEmpty($result);
+
+        // Attach a new role — this should bust the cache.
+        $newRole = factory(Role::class)->create();
+        (new User)->find($userId)->roles()->attach($newRole->id);
+
+        $cachedResult = $this->cache()->tags($tags)->get($hashedKey);
+
+        $this->assertNull($cachedResult, 'Expected cache to be invalidated after attach, but a cached value was found.');
+    }
+
+    // -------------------------------------------------------------------------
+    // AC2b: Cache is invalidated on detach
+    // -------------------------------------------------------------------------
+
+    public function testCacheIsInvalidatedWhenDetachingRole(): void
+    {
+        $userId = $this->userIdWithRoles();
+
+        $relation = (new User)->find($userId)->roles();
+        [$tags, $hashedKey] = $this->getCacheTagsAndKey($relation);
+
+        // Warm the cache.
+        $result = (new User)->find($userId)->roles;
+        $this->assertNotEmpty($result);
+
+        $firstRoleId = $result->first()->id;
+        (new User)->find($userId)->roles()->detach($firstRoleId);
+
+        $cachedResult = $this->cache()->tags($tags)->get($hashedKey);
+
+        $this->assertNull($cachedResult, 'Expected cache to be invalidated after detach, but a cached value was found.');
+    }
+
+    // -------------------------------------------------------------------------
+    // AC2c: Cache is invalidated on sync
+    // -------------------------------------------------------------------------
+
+    public function testCacheIsInvalidatedWhenSyncingRoles(): void
+    {
+        $userId = $this->userIdWithRoles();
+
+        $relation = (new User)->find($userId)->roles();
+        [$tags, $hashedKey] = $this->getCacheTagsAndKey($relation);
+
+        // Warm the cache.
+        $result = (new User)->find($userId)->roles;
+        $this->assertNotEmpty($result);
+
+        $newRoles = factory(Role::class, 2)->create();
+        (new User)->find($userId)->roles()->sync($newRoles->pluck('id'));
+
+        $cachedResult = $this->cache()->tags($tags)->get($hashedKey);
+
+        $this->assertNull($cachedResult, 'Expected cache to be invalidated after sync, but a cached value was found.');
+
+        // Verify the final roles match what was synced.
+        $this->assertEmpty(array_diff(
+            (new User)->find($userId)->roles->pluck('id')->toArray(),
+            $newRoles->pluck('id')->toArray()
+        ));
+    }
+}

--- a/tests/database/factories/RoleFactory.php
+++ b/tests/database/factories/RoleFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+use Faker\Generator as Faker;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Role;
+
+$factory->define(Role::class, function (Faker $faker) {
+    return [
+        'name' => $faker->unique()->word,
+    ];
+});

--- a/tests/database/migrations/2019_09_15_100006_create_roles_table.php
+++ b/tests/database/migrations/2019_09_15_100006_create_roles_table.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateRolesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/database/migrations/2019_09_15_100007_create_role_user.php
+++ b/tests/database/migrations/2019_09_15_100007_create_role_user.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateRoleUser extends Migration
+{
+    public function up()
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles')
+                ->onUpdate('CASCADE')
+                ->onDelete('CASCADE');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onUpdate('CASCADE')
+                ->onDelete('CASCADE');
+        });
+    }
+}

--- a/tests/database/seeds/DatabaseSeeder.php
+++ b/tests/database/seeds/DatabaseSeeder.php
@@ -10,6 +10,7 @@ use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Printer;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Profile;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Publisher;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Role;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Store;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Tag;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost;
@@ -21,8 +22,10 @@ class DatabaseSeeder extends Seeder
 {
     public function run()
     {
+        $roles = factory(Role::class, 3)->create();
         factory(History::class)->create();
         $user = factory(User::class)->create();
+        $user->roles()->sync($roles->pluck('id'));
         $image = factory(Image::class)->create([
             "imagable_id" => $user->id,
             "imagable_type" => User::class,


### PR DESCRIPTION
## What changed

The `Cachable` trait already correctly wires up `CachedBelongsToMany` when an
`Authenticatable`-based model uses `Cachable` and defines a `belongsToMany`
relationship to a `Cachable` related model. The bug reported in #473 is that
the reporter's owning model (`AdminUser`) did **not** use `Cachable` at all —
only the related model did. The fix there is user-side: add `Cachable` to the
owning model (as shown by the existing `User` fixture which already extends
`Authenticatable` and uses `Cachable`). The code path was simply **untested**.

This PR adds the missing fixture infrastructure and a full test suite:

### Added
- `tests/Fixtures/Role.php` — Cachable model with a `users()` belongsToMany
- `tests/Fixtures/UncachedRole.php` — plain model for uncached comparison
- `roles()` relationship added to `User` fixture (extends Authenticatable + uses Cachable)
- `roles()` relationship added to `UncachedUser` fixture
- Migration: `roles` table
- Migration: `role_user` pivot table
- `RoleFactory`
- `DatabaseSeeder` updated to seed 3 roles and attach them to the seeded user
- `AuthenticatableBelongsToManyTest` — 5 tests covering all AC

## Why

Issue #473 reports that `belongsToMany` doesn't use cache on a model extending
`Authenticatable`. Investigation confirms the existing code **does** work when
`Cachable` is on the owning model — it returns `CachedBelongsToMany` and
invalidates cache on attach/detach/sync. The gap was the lack of tests
specifically for the `Authenticatable` base class pattern.

## How to test

```bash
vendor/bin/phpunit tests/Integration/CachedBuilder/AuthenticatableBelongsToManyTest.php
```

Expected: 5 tests, 12 assertions, OK.

## Pre-existing failures (not introduced here)

- `PaginateTest` — HTML assertion mismatch (pre-existing)
- `WhereJsonContainsTest` x2 — pre-existing errors

closes #473