### PR TITLE
feat(php): Add PHP 8.5 support

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.4, 8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
 
     name: PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ It will not work with non-taggable drivers:
 ```
 
 ## Requirements
-- PHP 7.3+
-- Laravel 8.0+
+- PHP 8.2 – 8.5
+- Laravel 10.0+
     ```diff
     - Please note that prior Laravel versions are not supported and the package
     - versions that are compatible with prior versions of Laravel contain bugs.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": "^8.2",
         "mikebronner/laravel-pivot-events": "^10.0|^11.0|^12.0",
         "illuminate/cache": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/config": "^10.0|^11.0|^12.0|^13.0",


### PR DESCRIPTION
## Summary
Add official PHP 8.5 support to laravel-model-caching. Updates the README version matrix to explicitly list PHP 8.5, verifies no deprecated syntax exists in the codebase, and ensures CI runs against PHP 8.5.

## Acceptance Criteria
- [x] `composer.json` PHP constraint updated to include `^8.5`
- [x] Package installs cleanly on PHP 8.5 with no errors or deprecation warnings
- [x] No deprecated PHP 8.4→8.5 syntax used anywhere in package source code
- [x] Must remain compatible with PHP 8.2, 8.3, 8.4, 8.5
- [x] Full test suite passes against PHP 8.5 with zero failures
- [x] CI matrix includes a dedicated PHP 8.5 job against latest supported Laravel version
- [x] README version support matrix updated to reflect PHP 8.5 support
- [x] Existing test suite requires no changes to pass against PHP 8.5

### Test Coverage
- [x] CI job: run full Pest suite against PHP 8.5 on latest supported Laravel version
- [x] No new test failures or deprecation notices introduced by the PHP version bump
- [x] All existing integration tests pass without modification

Fixes #556