### PR TITLE
Call parent::__clone() in CachedBuilder clone method

### DIFF
--- a/src/CachedBuilder.php
+++ b/src/CachedBuilder.php
@@ -77,6 +77,7 @@ class CachedBuilder extends Builder
     {
         if ($this->innerBuilder) {
             $this->innerBuilder = clone $this->innerBuilder;
-        }
+        } 
+        parent::__clone();
     }
 }


### PR DESCRIPTION
---

### 🐛 Fix: Prevent query constraint leakage in `morphTo` due to improper builder cloning

#### Problem

When using `morphTo` relationships together with cached queries, constraints from the parent/intermediate model are incorrectly leaking into the related model query.

Example scenario:

```php
$table = new ExampleTable();
$table->items()->with('item')->get();
```

This produces an incorrect query like:

```sql
select * from products
where example_table_items.deleted_at is null
and products.item_type = 'service'
and products.item_id in (1,2,4)
```

The condition:

```
example_table_items.deleted_at is null
```

does **not belong** to the `products` query and should not be present.

---

#### Root Cause

The issue is caused by an incomplete implementation of the `__clone()` method in `CachedBuilder`.

`morphTo` relies on properly cloned query builders. However, since `CachedBuilder` overrides `__clone()` without calling `parent::__clone()`, internal state (such as `wheres`, scopes, and bindings) is not correctly isolated.

This results in constraint leakage between unrelated queries.

---

#### Solution

Call the parent clone method to ensure proper deep cloning of the underlying query builder:

```php
public function __clone()
{
    if ($this->innerBuilder) {
        $this->innerBuilder = clone $this->innerBuilder;
    }
    parent::__clone(); // add this line
}
```

---

#### Impact

This fix ensures:

* Proper isolation of query constraints
* Correct behavior of `morphTo` relationships
* No leakage of `SoftDeletes` or global scopes across models
* Consistency with Laravel's native `Builder` cloning behavior

---

#### Testing

It is recommended to validate with a case involving:

* A model using `SoftDeletes`
* An intermediate relation (e.g. `example_table_items`)
* A `morphTo` relation pointing to another model (e.g. `products`)

Ensure that the related model query does **not** include constraints from the intermediate table.

---

#### Notes

This change is minimal, backward-compatible, and aligns `CachedBuilder` with Laravel’s expected cloning behavior.

---

