### PR TITLE
🐛 fix(cache-key): cast integer-backed enum values to string in processEnum

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -526,7 +526,7 @@ class CacheKey
         BackedEnum|UnitEnum|Expression|DateTimeInterface|int|float|bool|string|null $value,
     ): string {
         if ($value instanceof BackedEnum) {
-            return $value->value;
+            return (string) $value->value;
         } elseif ($value instanceof UnitEnum) {
             return $value->name;
         } elseif ($value instanceof Expression) {

--- a/tests/Fixtures/IntegerStatus.php
+++ b/tests/Fixtures/IntegerStatus.php
@@ -1,0 +1,7 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+enum IntegerStatus: int
+{
+    case Active = 1;
+    case Inactive = 0;
+}

--- a/tests/Fixtures/StringStatus.php
+++ b/tests/Fixtures/StringStatus.php
@@ -1,0 +1,7 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+enum StringStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}

--- a/tests/Integration/CachedBuilder/WhereEnumTest.php
+++ b/tests/Integration/CachedBuilder/WhereEnumTest.php
@@ -1,0 +1,49 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\IntegerStatus;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\StringStatus;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+
+class WhereEnumTest extends IntegrationTestCase
+{
+    public function testWhereWithIntegerBackedEnum()
+    {
+        $authors = (new Author)
+            ->where('id', IntegerStatus::Active)
+            ->get();
+
+        $this->assertNotNull($authors);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $authors);
+    }
+
+    public function testWhereWithStringBackedEnum()
+    {
+        $authors = (new Author)
+            ->where('name', StringStatus::Active)
+            ->get();
+
+        $this->assertNotNull($authors);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $authors);
+    }
+
+    public function testWhereInWithIntegerBackedEnums()
+    {
+        $authors = (new Author)
+            ->whereIn('id', [IntegerStatus::Active, IntegerStatus::Inactive])
+            ->get();
+
+        $this->assertNotNull($authors);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $authors);
+    }
+
+    public function testWhereInWithStringBackedEnums()
+    {
+        $authors = (new Author)
+            ->whereIn('name', [StringStatus::Active, StringStatus::Inactive])
+            ->get();
+
+        $this->assertNotNull($authors);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $authors);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a `TypeError` in `CacheKey::expressionToString()` when a PHP integer-backed enum is used in a query `where()` clause. The `processEnum()` method returned the raw `int` value instead of casting it to `string`.

## Changes
- Cast `BackedEnum::value` to `(string)` in `CacheKey::processEnum()` to satisfy the `: string` return type
- Added test fixtures for integer-backed and string-backed enums
- Added integration tests covering `where()` and `whereIn()` with both enum types

## Acceptance Criteria
- [x] `CacheKey::expressionToString()` casts integer enum values to string before returning, satisfying the `string` return type declaration
- [x] Queries using PHP enums with integer-backed values (`int` backing type) no longer throw a `TypeError`
- [x] Queries using PHP enums with string-backed values continue to work as before (no regression)
- [x] The fix is covered by a test that uses an integer-backed enum in a `where()` clause
- [x] All existing tests pass with no regressions

## Test Coverage
- `WhereEnumTest::testWhereWithIntegerBackedEnum` — verifies integer-backed enum in `where()`
- `WhereEnumTest::testWhereWithStringBackedEnum` — verifies string-backed enum in `where()` (regression)
- `WhereEnumTest::testWhereInWithIntegerBackedEnums` — verifies integer-backed enums in `whereIn()`
- `WhereEnumTest::testWhereInWithStringBackedEnums` — verifies string-backed enums in `whereIn()` (regression)

Fixes #583