### PR TITLE
fix: support tpetry/laravel-postgresql-enhanced and custom expressions

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -7,7 +7,7 @@ namespace GeneaLabs\LaravelModelCaching;
 use BackedEnum;
 use DateTimeInterface;
 use GeneaLabs\LaravelModelCaching\Traits\CachePrefixing;
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;


### PR DESCRIPTION
Many packages such as tpetry/laravel-postgresql-enhanced add custom Expression classes that can be used for `where`, `whereIn`, etc. Many of these use the Contract and will fail when combined with model caching. We've had a class-override in our project for a few years that I just found when upgrading the package so opening pr for it :)