### PR TITLE
fix: 🐛 Fixed use of custom expressions.

### DIFF
--- a/tests/Fixtures/ContractOnlyExpression.php
+++ b/tests/Fixtures/ContractOnlyExpression.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use Illuminate\Database\Grammar;
+
+final class ContractOnlyExpression implements ExpressionContract
+{
+    public function __construct(private readonly string $value)
+    {
+    }
+
+    public function getValue(Grammar $grammar): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Integration/CachedBuilder/ContractExpressionTest.php
+++ b/tests/Integration/CachedBuilder/ContractExpressionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\ContractOnlyExpression;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+
+class ContractExpressionTest extends IntegrationTestCase
+{
+    /**
+     * Regression for PR #590. A custom Expression that implements
+     * Illuminate\Contracts\Database\Query\Expression but does NOT extend
+     * the concrete Illuminate\Database\Query\Expression must still be
+     * recognized by CacheKey's instanceof checks. Otherwise the object
+     * falls through into string concatenation in getOtherClauses() and
+     * triggers a fatal "Object of class … could not be converted to string".
+     */
+    public function test_cache_key_handles_contract_only_expression_as_where_column()
+    {
+        $expression = new ContractOnlyExpression('id');
+
+        $cached = (new Book)
+            ->where($expression, '>', 0)
+            ->get();
+
+        $live = (new UncachedBook)
+            ->where($expression, '>', 0)
+            ->get();
+
+        $this->assertNotEmpty($cached);
+        $this->assertEmpty($cached->diffKeys($live));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test that exercises a custom Expression class implementing only `Illuminate\Contracts\Database\Query\Expression` (without extending the concrete class), passed as the column argument to `where()`.
- Locks in the fix shipped in #590 — without that fix, this test fails with `Object of class … could not be converted to string` at `src/CacheKey.php:280`.
- Adds a small fixture (`ContractOnlyExpression`) modeling third-party Expression classes such as those in `tpetry/laravel-postgresql-enhanced`.

## Verification

- Verified failing on `master` immediately before #590 was merged (fatal at `src/CacheKey.php:280` in `getOtherClauses()`).
- Verified passing on `master` immediately after #590 was merged.
- Full suite: 381 tests, 991 assertions, 3 skipped (DynamoDB), 0 failures.

## Test plan

- [x] New test fails on the pre-#590 tree
- [x] New test passes on the post-#590 tree
- [x] `./vendor/bin/phpunit` — full suite green

Refs: #590