### PR TITLE
fix: 🐛 Honor enabled flag in flushCache() (#595) + fix order-dependent WhereJsonContains tests

### DIFF
--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -150,6 +150,10 @@ trait Caching
 
     public function flushCache(array $tags = [])
     {
+        if (! $this->isCachable()) {
+            return;
+        }
+
         $this->withCacheFallback(function () use ($tags) {
             if (count($tags) === 0) {
                 $tags = $this->makeCacheTags();

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -162,13 +162,8 @@ trait CreatesApplication
         }
 
         self::$baseLineDatabaseMigrated = true;
-
-        // Building the baseline database temporarily switches the default
-        // connection, so capture the connection the active test selected (via
-        // getEnvironmentSetUp) and restore it afterwards. Otherwise the first
-        // test in a process that overrides the connection (e.g.
-        // WhereJsonContainsTest → pgsql) gets silently clobbered onto sqlite.
-        $originalDefaultConnection = $this->app['config']->get('database.default');
+        $originalDefaultConnection = $this->app['config']
+            ->get('database.default');
 
         $databasePath = $this->testDatabaseDirectory();
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -163,6 +163,13 @@ trait CreatesApplication
 
         self::$baseLineDatabaseMigrated = true;
 
+        // Building the baseline database temporarily switches the default
+        // connection, so capture the connection the active test selected (via
+        // getEnvironmentSetUp) and restore it afterwards. Otherwise the first
+        // test in a process that overrides the connection (e.g.
+        // WhereJsonContainsTest → pgsql) gets silently clobbered onto sqlite.
+        $originalDefaultConnection = $this->app['config']->get('database.default');
+
         $databasePath = $this->testDatabaseDirectory();
 
         if (! is_dir(filename: $databasePath)) {
@@ -190,7 +197,7 @@ trait CreatesApplication
             '--database' => 'baseline',
         ]);
 
-        $this->app['config']->set('database.default', 'testing');
+        $this->app['config']->set('database.default', $originalDefaultConnection);
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/CachedBuilder/CacheFallbackTest.php
+++ b/tests/Integration/CachedBuilder/CacheFallbackTest.php
@@ -403,9 +403,6 @@ class CacheFallbackTest extends IntegrationTestCase
 
     public function testFlushCacheIsNoOpWhenCachingDisabled(): void
     {
-        // Regression for #595: when caching is disabled, flushCache() must
-        // short-circuit and never resolve or connect to the configured store —
-        // even when that store is unreachable and fallback-to-database is off.
         config(['laravel-model-caching.enabled' => false]);
         config(['laravel-model-caching.fallback-to-database' => false]);
         $this->breakCacheConnection();

--- a/tests/Integration/CachedBuilder/CacheFallbackTest.php
+++ b/tests/Integration/CachedBuilder/CacheFallbackTest.php
@@ -400,4 +400,18 @@ class CacheFallbackTest extends IntegrationTestCase
         $this->assertNotNull($authors);
         $this->assertNotEmpty($authors);
     }
+
+    public function testFlushCacheIsNoOpWhenCachingDisabled(): void
+    {
+        // Regression for #595: when caching is disabled, flushCache() must
+        // short-circuit and never resolve or connect to the configured store —
+        // even when that store is unreachable and fallback-to-database is off.
+        config(['laravel-model-caching.enabled' => false]);
+        config(['laravel-model-caching.fallback-to-database' => false]);
+        $this->breakCacheConnection();
+
+        $this->expectNotToPerformAssertions();
+
+        (new Author)->flushCache();
+    }
 }


### PR DESCRIPTION
## Summary

This PR contains two fixes:

1. **#595 — `flushCache()` ignored the `enabled` flag** (library fix).
2. **Order-dependent `WhereJsonContainsTest` failures** (test-harness fix) found while getting the suite green.

---

## 1. `flushCache()` honors the `enabled` flag (Fixes #595)

`flushCache()` was the only write-side entry point in the `Caching` trait that did **not**
check `isCachable()` before touching the store. The read path skips when disabled, and the
automatic flush on `saved`/`deleted` is gated by `checkCooldownAndFlushAfterPersisting()` — but
an **explicit** `$model->flushCache()` went straight to `cache($tags)->invalidateTags()`,
resolving and connecting to the store regardless of `laravel-model-caching.enabled`.

This bit hardest where caching is intentionally off but the configured store is unreachable
(e.g. `MODEL_CACHE_ENABLED=false` with `MODEL_CACHE_STORE` still pointing at a Redis cluster
that isn't part of the test stack): with the default `fallback-to-database=false`, the
connection exception was rethrown.

**Fix:** short-circuit `flushCache()` on `isCachable()` — the same guard the rest of the trait
uses. As a bonus it also hardens the cooldown-cleanup path (`checkCooldownAndRemoveIfExpired()`),
which calls `flushCache()` without its own guard.

```php
public function flushCache(array $tags = [])
{
    if (! $this->isCachable()) {
        return;
    }
    // ... existing body
}
```

**Test:** `testFlushCacheIsNoOpWhenCachingDisabled` (in `CacheFallbackTest`) reproduces the
report verbatim — caching disabled + unreachable store + `fallback-to-database=false` — and
asserts `flushCache()` does not throw. TDD: fails on unpatched code (`RedisException` through
the broken store), passes with the guard.

## 2. Baseline DB setup no longer clobbers the default connection

`CreatesApplication::setUpBaseLineSqlLiteDatabase()` runs once per process (static guard),
during the **first** test's `setUp()`, and afterwards hardcoded `database.default` back to
`'testing'`. That ran **after** the per-test `getEnvironmentSetUp()`, so whichever test ran
first and overrode the connection (e.g. `WhereJsonContainsTest` → `pgsql`) was silently
clobbered onto SQLite — where `whereJsonContains()` generates invalid SQL (`"json_each"."value"
is foo` → `column index out of range`) and the hardcoded `pgsql:testing` cache keys never match
(`Trying to access array offset on null`).

The result was **order-dependent** failures: `WhereJsonContainsTest` passed when it ran after
another test (default stayed `pgsql`) and errored when it ran first (clobbered to sqlite).

**Fix:** capture the active default connection before building the baseline and restore *that*
instead of hardcoding `'testing'`, so the baseline setup no longer leaks connection state across
tests.

## Test plan

- TDD on the #595 guard: red on unpatched code, green after.
- `WhereJsonContainsTest` now passes in **both** orderings (run first or later); verified by
  running the file and the array-only test in isolation.
- **Full suite: 382 tests, 991 assertions, 0 errors, 0 failures** (3 intentional skips). The 2
  pre-existing `WhereJsonContainsTest` errors are resolved with no new regressions.

Fixes #595
