### PR TITLE
fix: 🐛 Recover from Redis CROSSSLOT error on tagged cache flush.

### DIFF
--- a/src/Cache/ModelCacheRepository.php
+++ b/src/Cache/ModelCacheRepository.php
@@ -6,11 +6,14 @@ namespace GeneaLabs\LaravelModelCaching\Cache;
 
 use Illuminate\Cache\DynamoDbStore;
 use Illuminate\Cache\RedisStore;
+use Illuminate\Cache\RedisTagSet;
 use Illuminate\Cache\Repository;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Cache\TaggedCache;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
 
 class ModelCacheRepository
 {
@@ -114,7 +117,7 @@ class ModelCacheRepository
     public function invalidateTags(array $tags): void
     {
         if (! $this->usesDynamoDb) {
-            $this->repositoryFor($tags)->flush();
+            $this->flushTaggedCache($this->repositoryFor($tags));
 
             return;
         }
@@ -122,6 +125,52 @@ class ModelCacheRepository
         foreach ($this->normalizeTags($tags) as $tag) {
             $this->repository->forever($this->tagVersionKey($tag), $this->freshVersion());
         }
+    }
+
+    protected function flushTaggedCache(Repository|TaggedCache $repository): void
+    {
+        try {
+            $repository->flush();
+        } catch (Throwable $exception) {
+            if (
+                ! $repository instanceof TaggedCache
+                || ! $this->isCrossSlotException($exception)
+            ) {
+                throw $exception;
+            }
+
+            $this->flushTaggedCacheBySlot($repository);
+        }
+    }
+
+    protected function isCrossSlotException(\Throwable $exception): bool
+    {
+        return stripos($exception->getMessage(), 'CROSSSLOT') !== false;
+    }
+
+    protected function flushTaggedCacheBySlot(TaggedCache $repository): void
+    {
+        $store = $repository->getStore();
+
+        if (! $store instanceof RedisStore) {
+            throw new RuntimeException(
+                'Cannot recover from a cross-slot cache flush failure on a '
+                . 'non-Redis store.',
+            );
+        }
+
+        $tags = $repository->getTags();
+        $prefix = $store->getPrefix();
+        $connection = $store->connection();
+
+        if ($tags instanceof RedisTagSet) {
+            $tags->entries()
+                ->each(function (string $key) use ($connection, $prefix): void {
+                    $connection->del($prefix . $key);
+                });
+        }
+
+        $tags->flush();
     }
 
     public function invalidateAll(): void

--- a/tests/Fixtures/CrossSlotFlushRepository.php
+++ b/tests/Fixtures/CrossSlotFlushRepository.php
@@ -1,0 +1,20 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use Illuminate\Cache\RedisTagSet;
+use Illuminate\Cache\Repository;
+
+// A cache repository backed by the real Redis store, but whose tagged flush
+// raises CROSSSLOT — wiring CrossSlotTaggedCache over the genuine store so tests
+// reproduce the cluster failure without needing an actual multi-node cluster.
+class CrossSlotFlushRepository extends Repository
+{
+    public function tags($names)
+    {
+        $names = is_array($names) ? $names : func_get_args();
+
+        return new CrossSlotTaggedCache(
+            $this->getStore(),
+            new RedisTagSet($this->getStore(), $names),
+        );
+    }
+}

--- a/tests/Fixtures/CrossSlotTaggedCache.php
+++ b/tests/Fixtures/CrossSlotTaggedCache.php
@@ -1,0 +1,15 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use Illuminate\Cache\RedisTaggedCache;
+
+// Simulates a Redis Cluster reached through a single, non-cluster connection:
+// the multi-key Lua flush Laravel runs touches keys across hash slots and the
+// server rejects it. Everything else (entries(), del(), forget()) still routes
+// to the real store, so the slot-safe recovery path can be exercised end-to-end.
+class CrossSlotTaggedCache extends RedisTaggedCache
+{
+    public function flush()
+    {
+        throw new \RedisException("CROSSSLOT Keys in request don't hash to the same slot");
+    }
+}

--- a/tests/Integration/CachedBuilder/RedisClusterCrossSlotTest.php
+++ b/tests/Integration/CachedBuilder/RedisClusterCrossSlotTest.php
@@ -1,0 +1,82 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Cache\ModelCacheRepository;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\CrossSlotFlushRepository;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+
+// Regression coverage for issue #594: saving a model against a Redis Cluster
+// reached through a single (non-cluster) connection threw "CROSSSLOT Keys in
+// request don't hash to the same slot" because Laravel's tagged flush runs a
+// multi-key Lua script. invalidateTags() must recover via slot-safe deletes.
+class RedisClusterCrossSlotTest extends IntegrationTestCase
+{
+    private const TAG = 'cross-slot-tag';
+
+    public function testInvalidateTagsRecoversFromCrossSlotFailure(): void
+    {
+        $repository = app('cache')->store('model');
+        $store = $repository->getStore();
+
+        $repository->tags([self::TAG])->forever('entry-a', 'value-a');
+        $repository->tags([self::TAG])->forever('entry-b', 'value-b');
+
+        $this->assertSame('value-a', $repository->tags([self::TAG])->get('entry-a'));
+        $this->assertNotEmpty($this->modelCacheKeys());
+
+        $throwingRepository = new CrossSlotFlushRepository($store);
+        $modelCacheRepository = new ModelCacheRepository($throwingRepository, false);
+
+        // The CROSSSLOT exception must be swallowed in favor of the slot-safe path.
+        $modelCacheRepository->invalidateTags([self::TAG]);
+
+        // The cache is genuinely cleared, not merely namespaced away: every key
+        // written under the tag is physically removed, so no orphans leak.
+        $this->assertNull($repository->tags([self::TAG])->get('entry-a'));
+        $this->assertNull($repository->tags([self::TAG])->get('entry-b'));
+        $this->assertSame([], $this->modelCacheKeys());
+    }
+
+    public function testInvalidateTagsRethrowsNonCrossSlotFailures(): void
+    {
+        $store = app('cache')->store('model')->getStore();
+        $throwingRepository = new class($store) extends CrossSlotFlushRepository
+        {
+            public function tags($names)
+            {
+                $tagged = parent::tags($names);
+
+                return new class($tagged->getStore(), $tagged->getTags()) extends \Illuminate\Cache\RedisTaggedCache
+                {
+                    public function flush()
+                    {
+                        throw new \RedisException('READONLY You can\'t write against a read only replica.');
+                    }
+                };
+            }
+        };
+        $modelCacheRepository = new ModelCacheRepository($throwingRepository, false);
+
+        $this->expectException(\RedisException::class);
+
+        $modelCacheRepository->invalidateTags([self::TAG]);
+    }
+
+    private function modelCacheKeys(): array
+    {
+        $token = (int) env('TEST_TOKEN', 1);
+        $pattern = "lmc-test-{$token}:*";
+        $client = app('redis')->connection('model-cache')->client();
+        $cursor = null;
+        $keys = [];
+
+        do {
+            $found = $client->scan($cursor, $pattern, 1000);
+
+            if (is_array($found)) {
+                $keys = array_merge($keys, $found);
+            }
+        } while ($cursor > 0);
+
+        return $keys;
+    }
+}


### PR DESCRIPTION
Fixes #594 