### PR TITLE
Fix TypeError in CacheKey::expressionToString() for int-valued Expressions

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -549,6 +549,6 @@ class CacheKey
             return $value;
         }
 
-        return $value->getValue($this->query->getConnection()->getQueryGrammar());
+        return (string) $value->getValue($this->query->getConnection()->getQueryGrammar());
     }
 }

--- a/tests/Integration/CachedBuilder/WhereHasTest.php
+++ b/tests/Integration/CachedBuilder/WhereHasTest.php
@@ -19,6 +19,18 @@ class WhereHasTest extends IntegrationTestCase
         $this->assertEquals($authors->pluck("id"), $uncachedAuthors->pluck("id"));
     }
 
+    public function testCountedWhereHasClause()
+    {
+        $authors = (new Author)
+            ->whereHas("books", null, ">=", 2)
+            ->get();
+        $uncachedAuthors = (new UncachedAuthor)
+            ->whereHas("books", null, ">=", 2)
+            ->get();
+
+        $this->assertEquals($authors->pluck("id"), $uncachedAuthors->pluck("id"));
+    }
+
     public function testNestedWhereHasClauses()
     {
         $authors = (new Author)


### PR DESCRIPTION
## Summary
Implements #601

Since 12.0.4, `CacheKey.php` declares `strict_types=1`, but `expressionToString(): string` returned `$value->getValue($grammar)` unguarded. Laravel's counted `whereHas()`/`has()` (via `QueriesRelationships::addWhereCountQuery()`) wraps the count in an **int-valued** `Expression`, so cache-key generation threw:

```
TypeError: GeneaLabs\LaravelModelCaching\CacheKey::expressionToString(): Return value must be of type string, int returned
```

## Changes
- Cast the `Expression::getValue()` result to `(string)` in `CacheKey::expressionToString()` — covers int and float values; string-valued expressions are unaffected
- Add `testCountedWhereHasClause` regression test to `tests/Integration/CachedBuilder/WhereHasTest.php`, asserting a counted `whereHas()` on a cached model executes without error and matches the uncached model's result

## Acceptance Criteria
- [x] `CacheKey::expressionToString()` in `src/CacheKey.php` casts `$value->getValue($this->query->getConnection()->getQueryGrammar())` to `(string)` before returning, so int/float values returned by `Illuminate\Database\Query\Expression::getValue()` satisfy the `strict_types=1` `: string` return type
- [x] A counted `whereHas()`/`has()` query (e.g. `->whereHas('relation', null, '>=', 2)`) on a cached model no longer throws `TypeError: ... expressionToString(): Return value must be of type string, int returned`
- [x] New or updated integration test (in `tests/Integration/CachedBuilder/WhereHasTest.php`) covers a counted `whereHas()` clause against a cached model and asserts it executes without error and matches the uncached model's result
- [x] Existing `expressionToString()` call sites (order-by column, join `first`/`second`, where `column`) continue to behave unchanged for string-valued expressions
- [x] No behavior change for PHP versions/configs without `strict_types` enforcement issues (fix is a safe cast, not a conditional workaround)

## Test Plan
- [x] Regression test reproduces the exact TypeError before the fix and passes after it
- [x] Full Integration + Feature suite: 392 tests, 390 pass; the 2 `WhereJsonContainsTest` errors are environmental (no local PostgreSQL) and fail identically on `master` — CI provisions Postgres
- [x] Static analysis (phpstan): 372 baseline errors before and after — zero delta from this change
- [x] Pint: pre-existing style drift on touched files is unchanged (identical fixer list on `master`); new code matches sibling style

Fixes #601