### PR TITLE
Fix cache keys for deferred `ofMany` eager-load queries

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -24,6 +24,7 @@ class CacheKey
     protected $macroKey;
     protected $model;
     protected $query;
+    protected bool $hasBeforeQueryCallbacks;
     protected $withoutGlobalScopes = [];
     protected $withoutAllGlobalScopes = false;
 
@@ -35,6 +36,13 @@ class CacheKey
         array $withoutGlobalScopes,
         $withoutAllGlobalScopes
     ) {
+        $this->hasBeforeQueryCallbacks = $query->beforeQueryCallbacks !== [];
+
+        if ($this->hasBeforeQueryCallbacks) {
+            $query = clone $query;
+            $query->applyBeforeQueryCallbacks();
+        }
+
         $this->eagerLoad = $eagerLoad;
         $this->macroKey = $macroKey;
         $this->model = $model;
@@ -73,14 +81,20 @@ class CacheKey
         }
 
         if ($this->withoutAllGlobalScopes) {
-            return Arr::query($this->model->query()->withoutGlobalScopes()->getBindings());
+            $bindings = Arr::query($this->model->query()->withoutGlobalScopes()->getBindings());
+        } elseif (count($this->withoutGlobalScopes) > 0) {
+            $bindings = Arr::query($this->model->query()->withoutGlobalScopes($this->withoutGlobalScopes)->getBindings());
+        } else {
+            $bindings = Arr::query($this->model->query()->getBindings());
         }
 
-        if (count($this->withoutGlobalScopes) > 0) {
-            return Arr::query($this->model->query()->withoutGlobalScopes($this->withoutGlobalScopes)->getBindings());
+        if (! $this->hasBeforeQueryCallbacks) {
+            return $bindings;
         }
 
-        return Arr::query($this->model->query()->getBindings());
+        return $bindings . "-materialized_query_" . sha1(
+            $this->query->toSql() . "\0" . serialize($this->query->getBindings())
+        );
     }
 
     protected function getColumnClauses(array $where) : string

--- a/tests/Fixtures/Author.php
+++ b/tests/Fixtures/Author.php
@@ -45,6 +45,12 @@ class Author extends Model
         return $this->hasOne(Profile::class);
     }
 
+    public function oldestBook() : HasOne
+    {
+        return $this->hasOne(Book::class)
+            ->ofMany("id", "min");
+    }
+
     public function getLatestBookAttribute()
     {
         return $this

--- a/tests/Integration/CachedBuilder/PaginateTest.php
+++ b/tests/Integration/CachedBuilder/PaginateTest.php
@@ -189,4 +189,34 @@ class PaginateTest extends IntegrationTestCase
             "Paginator should not retain the original cached domain"
         );
     }
+
+    public function testPaginationRetainsOfManyEagerLoadsAcrossPages()
+    {
+        foreach (range(1, 2) as $index) {
+            $author = Author::factory()->create([
+                "name" => sprintf("Of Many Regression %02d", $index),
+            ]);
+
+            Book::factory()->create([
+                "author_id" => $author->id,
+                "title" => sprintf("Oldest Book %02d", $index),
+            ]);
+        }
+
+        $pageOne = (new Author)
+            ->disableModelCaching()
+            ->where("name", "LIKE", "Of Many Regression %")
+            ->orderBy("name")
+            ->with("oldestBook")
+            ->paginate(1, ["*"], "page", 1);
+        $pageTwo = (new Author)
+            ->disableModelCaching()
+            ->where("name", "LIKE", "Of Many Regression %")
+            ->orderBy("name")
+            ->with("oldestBook")
+            ->paginate(1, ["*"], "page", 2);
+
+        $this->assertSame($pageOne->first()->id, $pageOne->first()->oldestBook?->author_id);
+        $this->assertSame($pageTwo->first()->id, $pageTwo->first()->oldestBook?->author_id);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #604.

Laravel builds the aggregate subquery used by `HasOne::ofMany()` through a deferred `beforeQuery` callback. Laravel Model Caching previously generated the related-model cache key before that callback ran, so the key did not include the materialized join or its page-specific bindings.

This caused eager-loaded `ofMany()`, `oldestOfMany()`, and `latestOfMany()` relations on different pagination pages to share a cache entry. Later pages could receive related models belonging to the first page, which Eloquent could not match to their parent models, leaving the relations `null`.

## Changes

- Detect queries with deferred `beforeQuery` callbacks.
- Clone the query before applying those callbacks, leaving the original query untouched.
- Materialize the callbacks on the cloned query before generating the cache key.
- Append a hash of the materialized SQL and bindings to distinguish queries with different deferred state.
- Preserve the existing cache-key format for queries without deferred callbacks.
- Add regression coverage for an eager-loaded `ofMany()` relation across pagination pages.

The regression test disables model caching on the parent query while leaving the related model cacheable. This ensures the test exercises the relation cache key directly instead of passing because pagination caching was bypassed.