### PR TITLE
Cached `ofMany` eager-loaded relations return null on later paginated pages

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -60,10 +60,30 @@ class CacheKey
         $key .= $this->getOffsetClause();
         $key .= $this->getLimitClause();
         $key .= $this->getBindingsSlug();
+        $key .= $this->getDeferredCallbacksSlug();
         $key .= $keyDifferentiator;
         $key .= $this->macroKey;
 
         return $key;
+    }
+
+    protected function getDeferredCallbacksSlug() : string
+    {
+        if (! property_exists($this->query, "beforeQueryCallbacks")
+            || ! $this->query->beforeQueryCallbacks
+        ) {
+            return "";
+        }
+
+        // Queries like Eloquent's `ofMany()` relations build their joined
+        // subquery (and its bindings) lazily through `beforeQuery` callbacks,
+        // which only run at execution time — after this key was generated.
+        // Materialize them on a clone so the key reflects the SQL that will
+        // actually run, without mutating the query Laravel executes.
+        $query = clone $this->query;
+        $sql = $query->toSql();
+
+        return "-beforeQuery_" . sha1($sql . json_encode($query->getBindings()));
     }
 
     protected function getBindingsSlug() : string

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -80,10 +80,36 @@ class CacheKey
         // which only run at execution time — after this key was generated.
         // Materialize them on a clone so the key reflects the SQL that will
         // actually run, without mutating the query Laravel executes.
-        $query = clone $this->query;
-        $sql = $query->toSql();
+        //
+        // Boundary notes: the callbacks are shared by reference with the
+        // original query, so materializing here means they run once per key
+        // computation and again at execution — harmless for Eloquent's
+        // idempotent, self-clearing `ofMany()` family, but a custom
+        // non-idempotent `beforeQuery` callback would observe the extra
+        // invocation. The shallow clone also only isolates this outer query:
+        // a composite `ofMany(["a", "b"])` subquery carries its own nested
+        // `beforeQuery` callback on a shared subquery object.
+        try {
+            $query = clone $this->query;
+            $sql = $query->toSql();
 
-        return "-beforeQuery_" . sha1($sql . json_encode($query->getBindings()));
+            return "-beforeQuery_" . sha1($sql . $this->encodeForKeyHash($query->getBindings()));
+        } catch (Throwable) {
+            return "";
+        }
+    }
+
+    protected function encodeForKeyHash($value) : string
+    {
+        $encoded = json_encode($value);
+
+        // json_encode() returns false — not a string — when any nested value
+        // is a non-UTF-8 byte string (e.g. a raw binary(16) UUID key), which
+        // would silently erase the value from the hash and let differing
+        // queries collide on one cache key. serialize() is binary-safe;
+        // valid-UTF-8 values keep the exact json_encode() output so existing
+        // cache keys are unchanged.
+        return $encoded === false ? serialize($value) : $encoded;
     }
 
     protected function getBindingsSlug() : string
@@ -510,7 +536,7 @@ class CacheKey
                 return "";
             }
 
-            return "=" . sha1(json_encode($addedWheres) . json_encode($addedBindings));
+            return "=" . sha1($this->encodeForKeyHash($addedWheres) . $this->encodeForKeyHash($addedBindings));
         } catch (Throwable) {
             return "";
         }

--- a/tests/Fixtures/Author.php
+++ b/tests/Fixtures/Author.php
@@ -35,6 +35,24 @@ class Author extends Model
         return $this->hasMany(Book::class);
     }
 
+    public function oldestBook() : HasOne
+    {
+        return $this->hasOne(Book::class)
+            ->ofMany("id", "min");
+    }
+
+    public function firstBook() : HasOne
+    {
+        return $this->hasOne(Book::class)
+            ->oldestOfMany();
+    }
+
+    public function newestBook() : HasOne
+    {
+        return $this->hasOne(Book::class)
+            ->latestOfMany();
+    }
+
     public function printers() : HasManyThrough
     {
         return $this->hasManyThrough(Printer::class, Book::class);

--- a/tests/Integration/CachedBuilder/OfManyTest.php
+++ b/tests/Integration/CachedBuilder/OfManyTest.php
@@ -1,0 +1,108 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+
+class OfManyTest extends IntegrationTestCase
+{
+    public function testPaginatedOfManyEagerLoadReturnsCorrectRelationOnLaterPages()
+    {
+        $pageOne = (new Author)
+            ->with("oldestBook")
+            ->orderBy("id")
+            ->paginate(perPage: 1, page: 1);
+        $pageTwo = (new Author)
+            ->with("oldestBook")
+            ->orderBy("id")
+            ->paginate(perPage: 1, page: 2);
+
+        $authorOne = $pageOne->first();
+        $authorTwo = $pageTwo->first();
+
+        $this->assertNotNull($authorOne->oldestBook);
+        $this->assertNotNull($authorTwo->oldestBook);
+        $this->assertEquals(
+            (new UncachedBook)->where("author_id", $authorTwo->id)->min("id"),
+            $authorTwo->oldestBook->id,
+        );
+    }
+
+    public function testPaginatedOldestOfManyEagerLoadReturnsCorrectRelationOnLaterPages()
+    {
+        (new Author)
+            ->with("firstBook")
+            ->orderBy("id")
+            ->paginate(perPage: 1, page: 1);
+        $pageTwo = (new Author)
+            ->with("firstBook")
+            ->orderBy("id")
+            ->paginate(perPage: 1, page: 2);
+
+        $authorTwo = $pageTwo->first();
+
+        $this->assertNotNull($authorTwo->firstBook);
+        $this->assertEquals(
+            (new UncachedBook)->where("author_id", $authorTwo->id)->min("id"),
+            $authorTwo->firstBook->id,
+        );
+    }
+
+    public function testPaginatedLatestOfManyEagerLoadReturnsCorrectRelationOnLaterPages()
+    {
+        (new Author)
+            ->with("newestBook")
+            ->orderBy("id")
+            ->paginate(perPage: 1, page: 1);
+        $pageTwo = (new Author)
+            ->with("newestBook")
+            ->orderBy("id")
+            ->paginate(perPage: 1, page: 2);
+
+        $authorTwo = $pageTwo->first();
+
+        $this->assertNotNull($authorTwo->newestBook);
+        $this->assertEquals(
+            (new UncachedBook)->where("author_id", $authorTwo->id)->max("id"),
+            $authorTwo->newestBook->id,
+        );
+    }
+
+    public function testOfManyQueriesWithDifferentBindingsProduceDifferentCacheKeys()
+    {
+        $authors = (new Author)->orderBy("id")->take(2)->get();
+
+        $keys = $authors
+            ->map(function (Author $author) {
+                $relation = $author->oldestBook();
+                $relation->addEagerConstraints([$author]);
+
+                return (new \GeneaLabs\LaravelModelCaching\CacheKey(
+                    [],
+                    $relation->getRelated(),
+                    $relation->getQuery()->getQuery(),
+                    "",
+                    [],
+                    false,
+                ))
+                    ->make(["*"]);
+            });
+
+        $this->assertNotEquals($keys->first(), $keys->last());
+    }
+
+    public function testQueriesWithoutDeferredCallbacksKeepTheirCacheKeyFormat()
+    {
+        $key = (new \GeneaLabs\LaravelModelCaching\CacheKey(
+            [],
+            new Author,
+            (new Author)->newQueryWithoutScopes()->getQuery(),
+            "",
+            [],
+            false,
+        ))
+            ->make(["*"]);
+
+        $this->assertStringNotContainsString("beforeQuery", $key);
+    }
+}

--- a/tests/Integration/CachedBuilder/OfManyTest.php
+++ b/tests/Integration/CachedBuilder/OfManyTest.php
@@ -91,6 +91,32 @@ class OfManyTest extends IntegrationTestCase
         $this->assertNotEquals($keys->first(), $keys->last());
     }
 
+    public function testDeferredQueriesWithDifferentBinaryBindingsProduceDifferentCacheKeys()
+    {
+        $keys = collect([
+            hex2bin("ffd8ffe000104a4649460001abcdef01"),
+            hex2bin("ffd8ffe000104a4649460001abcdef02"),
+        ])
+            ->map(function (string $binaryId) {
+                $query = (new Author)->newQueryWithoutScopes()->getQuery();
+                $query->beforeQuery(function ($query) use ($binaryId) {
+                    $query->where("id", $binaryId);
+                });
+
+                return (new \GeneaLabs\LaravelModelCaching\CacheKey(
+                    [],
+                    new Author,
+                    $query,
+                    "",
+                    [],
+                    false,
+                ))
+                    ->make(["*"]);
+            });
+
+        $this->assertNotEquals($keys->first(), $keys->last());
+    }
+
     public function testQueriesWithoutDeferredCallbacksKeepTheirCacheKeyFormat()
     {
         $key = (new \GeneaLabs\LaravelModelCaching\CacheKey(
@@ -103,6 +129,9 @@ class OfManyTest extends IntegrationTestCase
         ))
             ->make(["*"]);
 
-        $this->assertStringNotContainsString("beforeQuery", $key);
+        $this->assertEquals(
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor",
+            $key,
+        );
     }
 }


### PR DESCRIPTION
## Summary
Implements #604

Cached `HasOne::ofMany()` eager loads returned `null` on later paginated pages: Laravel adds the page's parent IDs to the `ofMany` joined subquery lazily via `beforeQuery` callbacks at execution time, but the related-model cache key was generated before those callbacks ran — so every page shared page one's cache entry.

## Changes
- `CacheKey::make()` appends a new `getDeferredCallbacksSlug()` component: when the query has pending `beforeQuery` callbacks, they are materialized on a **clone** of the query builder (`toSql()` applies them) and the resulting SQL + bindings are hashed into the key. The executed query is never mutated.
- Queries with no deferred callbacks return an empty slug — their cache-key format is byte-for-byte unchanged.
- **Binding hashing is binary-safe** (review round 2): `json_encode()` returns `false` for non-UTF-8 byte strings (e.g. raw `binary(16)` UUID keys), which would have silently erased the bindings from the hash and re-introduced the page collision. A shared `encodeForKeyHash()` helper falls back to `serialize()` when `json_encode()` fails — valid-UTF-8 bindings keep their exact previous encoding. The same fix is applied to the pre-existing identical pattern in `getEagerLoadConstraintKey()`.
- **Deferred materialization is guarded** (review round 2): `getDeferredCallbacksSlug()` wraps the speculative `toSql()`/`getBindings()` in `try { … } catch (Throwable) { return ""; }`, mirroring `getEagerLoadConstraintKey()`'s convention, so a throwing callback can't break key generation.
- Boundary notes document the double-invocation of shared `beforeQuery` callbacks (harmless for Eloquent's idempotent `ofMany` family) and the composite `ofMany(['a','b'])` nested-subquery case.
- Added `oldestBook` (`ofMany('id', 'min')`), `firstBook` (`oldestOfMany()`), and `newestBook` (`latestOfMany()`) relations to the `Author` test fixture.
- New `OfManyTest` integration tests covering the paginated regression scenario for all three relation styles, cache-key uniqueness across pages **including distinct binary bindings**, and a pinned full-key assertion proving ordinary queries' key format is unchanged.

## Acceptance Criteria
- [x] `CacheKey` generation accounts for query builders with deferred `beforeQuery` callbacks (as used by Eloquent's `ofMany()`/`oldestOfMany()`/`latestOfMany()` relations) so the generated cache key reflects the materialized SQL and bindings those callbacks add, not just the pre-callback query state
- [x] Materializing the deferred callbacks for key generation is done on a clone of the underlying query builder, so cache-key generation never mutates the query object Laravel will actually execute
- [x] Queries with no deferred `beforeQuery` callbacks keep the exact same cache-key format as before this change (no unnecessary invalidation of existing cache entries for ordinary queries) — now pinned byte-for-byte by `testQueriesWithoutDeferredCallbacksKeepTheirCacheKeyFormat`
- [x] A paginated eager load of a `HasOne::ofMany()` relation (e.g. `->with('oldestBook')->paginate(1, page: 1)` then `page: 2`) returns the correct related model for each page, even when page one's query already warmed the related-model cache
- [x] The fix also covers the `oldestOfMany()` and `latestOfMany()` convenience methods, since they share the same deferred-query mechanism
- [x] A regression/integration test reproduces the reported scenario: two paginated queries (perPage 1, pages 1 and 2) against a model with an `ofMany` relation, asserting page two's eager-loaded relation is not `null` and matches the correct related record after page one has already populated the cache
- [x] Existing eager-loading and relationship cache-key tests (e.g. `CachedBuilderRelationshipsTest`) continue to pass unmodified, confirming no behavior change for non-`ofMany` eager loads

## Test Plan
- [x] Full suite green locally: 398 tests, 1026 assertions (4 pre-existing env-dependent skips)
- [x] `OfManyTest` fails on unmodified `src` and passes with the fix — including the new binary-bindings regression test, verified failing against the pre-round-2 `getDeferredCallbacksSlug()`
- [x] phpstan output identical before/after the change (372 findings, all pre-existing baseline drift)
- [x] No reformatting of pre-existing style (repo is not pint-clean at baseline; CI runs phpunit only)

Fixes #604