### PR TITLE
Tag relation queries with their joined tables

### DIFF
--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -12,11 +12,11 @@ use GeneaLabs\LaravelModelCaching\CacheKey;
 use GeneaLabs\LaravelModelCaching\CacheTags;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use ReflectionClass;
@@ -237,11 +237,17 @@ trait Caching
         $model = $this->getModel() instanceof Model
             ? $this->getModel()
             : $this;
-        $query = $this->query instanceof Builder
-            ? $this->query
-            : Container::getInstance()
+        $query = $this->query
+            ?? Container::getInstance()
                 ->make("db")
                 ->query();
+
+        // Relation classes hold an Eloquent builder here, not a query builder.
+        // Unwrap it as makeCacheKey() does, so joined tables get tagged.
+        if ($this->query && method_exists($this->query, "getQuery")) {
+            $query = $this->query->getQuery();
+        }
+
         $tags = (new CacheTags($eagerLoad, $model, $query))
             ->make();
 
@@ -501,7 +507,7 @@ trait Caching
         if (property_exists($this, 'query') && $this->query) {
             $baseQuery = $this->query;
 
-            if ($baseQuery instanceof \Illuminate\Database\Eloquent\Builder) {
+            if ($baseQuery instanceof Builder) {
                 $baseQuery = $baseQuery->getQuery();
             }
 

--- a/tests/Fixtures/CachableRoleUser.php
+++ b/tests/Fixtures/CachableRoleUser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use GeneaLabs\LaravelModelCaching\Traits\Cachable;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Cachable pivot model for the role_user table.
+ * Used to test that writes to a pivot table invalidate relations joining it.
+ */
+class CachableRoleUser extends Pivot
+{
+    use Cachable;
+
+    protected $table = 'role_user';
+    protected $fillable = [
+        'role_id',
+        'user_id',
+    ];
+}

--- a/tests/Integration/CachedBuilder/BelongsToManyTest.php
+++ b/tests/Integration/CachedBuilder/BelongsToManyTest.php
@@ -25,6 +25,8 @@ class BelongsToManyTest extends IntegrationTestCase
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesstore",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:stores",
+            // The relation JOINs the pivot table, so it is tagged with it too.
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:book-store",
         ];
 
         $stores = (new Book)

--- a/tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php
+++ b/tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php
@@ -3,8 +3,14 @@
 use GeneaLabs\LaravelModelCaching\CacheTags;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\CachableRoleUser;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Store;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\User;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use ReflectionMethod;
 
 class JoinCacheInvalidationTest extends IntegrationTestCase
 {
@@ -89,6 +95,76 @@ class JoinCacheInvalidationTest extends IntegrationTestCase
             0,
             $matchingRows->count(),
             'Left join query should return fresh data after the joined model is updated'
+        );
+    }
+
+    public function testRelationQueryCacheTagsContainPivotTableTag()
+    {
+        // Via makeCacheTags(), the only caller the caching path actually uses
+        $relation = (new Book)
+            ->first()
+            ->stores();
+        $method = new ReflectionMethod($relation, 'makeCacheTags');
+        $method->setAccessible(true);
+        $tags = $method->invoke($relation);
+
+        $pivotTableTag = (new Str)->slug('book_store');
+
+        $this->assertTrue(
+            collect($tags)->contains(function ($tag) {
+                return str_contains($tag, (new Str)->slug(Store::class));
+            }),
+            'Tags should include the related model class tag',
+        );
+
+        $this->assertTrue(
+            collect($tags)->contains(function ($tag) use ($pivotTableTag) {
+                return str_contains($tag, $pivotTableTag);
+            }),
+            'Tags should include the pivot table joined by the relation',
+        );
+    }
+
+    public function testMorphToManyQueryCacheTagsContainPivotTableTag()
+    {
+        $relation = (new Post)
+            ->first()
+            ->tags();
+        $method = new ReflectionMethod($relation, 'makeCacheTags');
+        $method->setAccessible(true);
+        $tags = $method->invoke($relation);
+
+        $pivotTableTag = (new Str)->slug('taggables');
+
+        $this->assertTrue(
+            collect($tags)->contains(function ($tag) use ($pivotTableTag) {
+                return str_contains($tag, $pivotTableTag);
+            }),
+            'Tags should include the pivot table joined by the polymorphic relation',
+        );
+    }
+
+    public function testBelongsToManyCacheInvalidatesWhenPivotTableIsWrittenByModel()
+    {
+        $userId = (int) DB::table('role_user')
+            ->value('user_id');
+        $user = (new User)
+            ->find($userId);
+
+        // Prime the read: its tags name Role and roles, the delete writes role_user
+        $this->assertGreaterThan(0, $user->roles()->count());
+
+        // Bulk delete through a cachable model whose table IS the pivot, so no
+        // pivot events fire and only the executed query's tags are invalidated
+        (new CachableRoleUser)
+            ->newQuery()
+            ->where('user_id', $userId)
+            ->delete();
+
+        $this->assertSame(
+            0,
+            $user->roles()->count(),
+            'BelongsToMany query should return fresh data after its pivot table is written',
         );
     }
 }


### PR DESCRIPTION
Fixes #610 

## Problem

A cached `BelongsToMany`/`MorphToMany` read keeps serving rows after a write to the pivot table it joins has already removed them.

Join tags were added in #577 so that a write to any joined table invalidates queries joining it. Relation queries never receive those tags, so the mechanism cannot fire for them.

## Cause

`Caching::makeCacheTags()` keeps the query only when it is already a `Query\Builder`:

```php
$query = $this->query instanceof Builder
    ? $this->query
    : Container::getInstance()->make("db")->query();
```

`CachedBuilder` holds a `Query\Builder` there and passes. But relation classes — `CachedBelongsToMany`, `CachedMorphToMany`, `CachedHasManyThrough`, `CachedHasOneThrough` — hold an **Eloquent** builder, so the real query is replaced with a fresh empty one. `CacheTags::getJoinTags()` then reads `$query->joins` on that empty query, finds nothing, and returns `[]`.

`makeCacheKey()` ten lines above already handles this via `method_exists($this->query, "getQuery")`. So the cache **key** is computed from the real query while the **tags** are computed from an empty one.

`CacheTags::getJoinTags()` even has its own `getQuery()` unwrap — it just never receives a builder to unwrap.

## Fix

Resolve the query in `makeCacheTags()` the same way `makeCacheKey()` does. `Query\Builder` has no `getQuery()`, so plain query builders pass through untouched and `CachedBuilder` behaviour is unchanged; only relation classes newly resolve to their underlying query.

The `Query\Builder` import becomes unused and is removed. That frees the name `Builder` for the already-fully-qualified `\Illuminate\Database\Eloquent\Builder` reference in `isCachable()`, which Pint then shortens — hence the third hunk in that file. Happy to drop that hunk and keep the dead import if you would rather the diff touch nothing else.

## Why existing coverage did not catch it

`JoinCacheInvalidationTest::testJoinQueryCacheTagsContainJoinedTableTag` constructs `CacheTags` directly and hands it the Eloquent builder:

```php
// CacheTags expects the Eloquent builder (CachedBuilder), which has getQuery()
$tags = (new CacheTags($query->getEagerLoads(), $query->getModel(), $query))->make();
```

`getJoinTags()` unwraps internally, so that passes — while `makeCacheTags()`, the only caller in the caching path and the one place the query is dropped, is never exercised. The new tests go through `makeCacheTags()` for that reason.

## Tests

Three added to `JoinCacheInvalidationTest`, all failing before this change:

- `testRelationQueryCacheTagsContainPivotTableTag` — `Book::stores()` tags include `book_store`
- `testMorphToManyQueryCacheTagsContainPivotTableTag` — `Post::tags()` tags include `taggables`
- `testBelongsToManyCacheInvalidatesWhenPivotTableIsWrittenByModel` — a primed `User::roles()` read is fresh after a bulk delete through a cachable model whose table is `role_user`

The last one needs a new `CachableRoleUser` fixture. A bulk write only flushes the pivot table's tag if it goes through a `Cachable` model whose table *is* the pivot; the existing `RoleUser` pivot is not cachable, so a delete through it invalidates nothing. This mirrors how custom pivot models are used in practice.

`BelongsToManyTest::testLazyLoadingRelationship` reads a cached entry back via `->tags($tags)->get($key)`. Tags namespace the key, so a two-tag read cannot find an entry written under three; it gains the new join tag. That is an expectation update, not a behaviour change — the surrounding assertions still compare the cached read against `UncachedBook`.

**Suite:** 395 tests, 1013 assertions, run as CI does (`--configuration phpunit.xml.dist --testsuite Integration,Feature`). The 2 remaining errors are `WhereJsonContainsTest::testWithInUsingCollectionQuery{,WithArrayValues}`, which fail identically on unmodified `master` in the same environment and are unrelated to this change.

**Pint:** `src/Traits/Caching.php` and the new fixture pass `pint.json`, and my added code follows the configured rules including `trailing_comma_in_multiline`. I did not run Pint across the two existing test files I touched: the `laravel` preset's `php_unit_method_casing` rule (not set in `pint.json`) renames every committed test method to snake_case, which would bury this change in unrelated churn. Their Pint status is byte-for-byte what it is on `master`. Say the word if you would prefer that reformatting included.

## Compatibility

Widens tags on relation reads only — it adds join-table tags and removes none — so invalidation becomes strictly more correct, never less. Because tags namespace the cache key, previously cached relation entries are orphaned rather than served stale after upgrade.

## How this surfaced

Found in a Laravel 13 app where one pivot table is read two ways: a `morphToMany` of the related records, and a `morphMany` of the pivot rows themselves (a custom pivot model with extra columns and soft deletes). Removing pivot rows through the `morphMany` side left the `morphToMany` read serving the detached records indefinitely.
