### PR TITLE
BelongsToMany/MorphToMany/*Through relation caches serve stale rows after the joined pivot table is written

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,11 @@ Cache tags are generated for the primary model, each eager-loaded relationship,
 joined tables, and morph-to target types, so only the relevant entries are
 invalidated. 🎯
 
+Joined tables include the pivot or intermediate table of a `belongsToMany`,
+`morphToMany`, `hasManyThrough`, or `hasOneThrough` relationship. Writing rows
+of that table through its own `Cachable` model therefore invalidates cached
+reads of the relationship.
+
 ### 🔗 BelongsToMany with Custom Pivot Models
 Cache invalidation works for `BelongsToMany` relationships using custom pivot
 models (`->using(CustomPivot::class)`) as long as either the parent or the

--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use ReflectionClass;
@@ -237,11 +236,18 @@ trait Caching
         $model = $this->getModel() instanceof Model
             ? $this->getModel()
             : $this;
-        $query = $this->query instanceof Builder
-            ? $this->query
-            : Container::getInstance()
+        $query = $this->query
+            ?? Container::getInstance()
                 ->make("db")
                 ->query();
+
+        if (
+            $this->query
+            && method_exists($this->query, "getQuery")
+        ) {
+            $query = $this->query->getQuery();
+        }
+
         $tags = (new CacheTags($eagerLoad, $model, $query))
             ->make();
 

--- a/tests/Fixtures/CachableRoleUser.php
+++ b/tests/Fixtures/CachableRoleUser.php
@@ -1,0 +1,21 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use GeneaLabs\LaravelModelCaching\Traits\Cachable;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Cachable model over the role_user pivot table.
+ * Used to test that writing pivot rows through their own cachable model
+ * invalidates relation caches that join that pivot table (issue #610).
+ */
+class CachableRoleUser extends Model
+{
+    use Cachable;
+
+    protected $table = 'role_user';
+
+    protected $fillable = [
+        'role_id',
+        'user_id',
+    ];
+}

--- a/tests/Integration/CachedBuilder/BelongsToManyTest.php
+++ b/tests/Integration/CachedBuilder/BelongsToManyTest.php
@@ -25,6 +25,7 @@ class BelongsToManyTest extends IntegrationTestCase
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesstore",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:stores",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:book-store",
         ];
 
         $stores = (new Book)

--- a/tests/Integration/CachedBuilder/RelationJoinCacheInvalidationTest.php
+++ b/tests/Integration/CachedBuilder/RelationJoinCacheInvalidationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\CachableRoleUser;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Supplier;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\User;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use ReflectionMethod;
+
+/**
+ * Regression tests for issue #610: relation queries that join a pivot or
+ * intermediate table were never tagged with that table, so a write to it
+ * could not invalidate the cached relation read.
+ */
+class RelationJoinCacheInvalidationTest extends IntegrationTestCase
+{
+    private function makeCacheTags(object $subject): array
+    {
+        $method = new ReflectionMethod($subject, 'makeCacheTags');
+        $method->setAccessible(true);
+
+        return $method->invoke($subject);
+    }
+
+    private function assertTagsContainTable(array $tags, string $table): void
+    {
+        $suffix = ':' . (new Str)->slug($table);
+
+        $this->assertTrue(
+            collect($tags)->contains(fn ($tag) => str_ends_with($tag, $suffix)),
+            "Relation cache tags should contain a tag for the joined table '{$table}'. Got: "
+                . implode(', ', $tags)
+        );
+    }
+
+    public function testBelongsToManyRelationTagsContainPivotTable(): void
+    {
+        $tags = $this->makeCacheTags((new Book)->first()->stores());
+
+        $this->assertTagsContainTable($tags, 'book_store');
+        $this->assertTagsContainTable($tags, 'stores');
+    }
+
+    public function testMorphToManyRelationTagsContainPivotTable(): void
+    {
+        $tags = $this->makeCacheTags((new Post)->first()->tags());
+
+        $this->assertTagsContainTable($tags, 'taggables');
+        $this->assertTagsContainTable($tags, 'tags');
+    }
+
+    /**
+     * CachedHasOneThrough and CachedHasManyThrough override makeCacheTags() and
+     * already unwrap the Eloquent builder, so the trait fix does not change them.
+     * This guards that behavior against regression.
+     */
+    public function testHasOneThroughRelationStillTagsIntermediateTable(): void
+    {
+        $tags = $this->makeCacheTags((new Supplier)->first()->history());
+
+        $this->assertTagsContainTable($tags, 'users');
+    }
+
+    public function testPlainBuilderJoinTagsStillResolveThroughMakeCacheTags(): void
+    {
+        $tags = $this->makeCacheTags(
+            (new Author)
+                ->select('authors.*', 'books.title')
+                ->join('books', 'books.author_id', '=', 'authors.id')
+        );
+
+        $this->assertTagsContainTable($tags, 'books');
+        $this->assertTagsContainTable($tags, 'authors');
+    }
+
+    public function testCachedBelongsToManyReadIsInvalidatedByPivotTableWrite(): void
+    {
+        $userId = (int) DB::table('role_user')->value('user_id');
+
+        $primedCount = (new User)->find($userId)->roles()->count();
+        $this->assertGreaterThan(0, $primedCount);
+
+        (new CachableRoleUser)
+            ->where('user_id', $userId)
+            ->first()
+            ->delete();
+
+        $this->assertSame(
+            $primedCount - 1,
+            (new User)->find($userId)->roles()->count(),
+            'A cached belongsToMany read should be invalidated by a write to its pivot table.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Implements #610

A cached read of a `BelongsToMany` or `MorphToMany` relation kept serving stale rows after its pivot table was written. `Traits\Caching::makeCacheTags()` only unwrapped `$this->query` when it was already an `Illuminate\Database\Query\Builder`. The relation classes hold an Eloquent builder there, so the check failed and the real query was replaced by an empty `db()->query()`. `CacheTags::getJoinTags()` then found no joins and produced no join tags, so the pivot table could never invalidate the cached read.

`makeCacheTags()` now resolves the query the same way `makeCacheKey()` already did, through `getQuery()`. Key and tags are computed from the same query again.

One correction to the issue's scope: `CachedHasManyThrough` and `CachedHasOneThrough` override `makeCacheTags()` and already unwrapped the builder, so the *Through relations were not affected. A test guards that they stay correct.

## Changes
- `src/Traits/Caching.php` — `makeCacheTags()` unwraps an Eloquent builder via `getQuery()` instead of gating on `instanceof Query\Builder`. The now-unused `Query\Builder` import is removed; `isCachable()` uses a fully qualified `Eloquent\Builder` and is untouched.
- `tests/Fixtures/CachableRoleUser.php` — new `Cachable` model over the `role_user` pivot table.
- `tests/Integration/CachedBuilder/RelationJoinCacheInvalidationTest.php` — new regression suite.
- `tests/Integration/CachedBuilder/BelongsToManyTest.php` — `testLazyLoadingRelationship` asserts the exact tag set of a lazy-loaded `belongsToMany` read, so it gains the `book-store` pivot tag.
- `README.md` — states that joined tables include pivot and intermediate tables.

## Acceptance Criteria
- [x] `makeCacheTags()` resolves `$this->query` the same way `makeCacheKey()` does.
- [x] `BelongsToMany` tags include the pivot table (`book_store`) — `testBelongsToManyRelationTagsContainPivotTable`.
- [x] `MorphToMany` tags include the polymorphic pivot table (`taggables`) — `testMorphToManyRelationTagsContainPivotTable`.
- [x] A write to `role_user` through a cachable pivot model invalidates a cached `$user->roles()->count()` — `testCachedBelongsToManyReadIsInvalidatedByPivotTableWrite`.
- [x] Plain `CachedBuilder` tagging is unchanged; `tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php` passes unmodified. `testPlainBuilderJoinTagsStillResolveThroughMakeCacheTags` closes the coverage gap the issue named — it drives a plain join query through `makeCacheTags()`, which the existing suite never did.
- [x] `isCachable()`'s `Eloquent\Builder` check is unaffected; its tests pass.
- [x] New tests demonstrate all of the above and pass.

## Test Plan
- [x] Full suite: 403 tests, 1035 assertions, 0 failures. 4 tests skip locally because they need external services (PostgreSQL, Redis cluster); CI runs them. `master` skips the same 4.
- [x] Mutation-tested: reverting the `makeCacheTags()` change turns the two tag tests and the invalidation test red.
- [x] The `*Through` guard test is documented as covering pre-existing override behavior, not this fix.

Fixes #610
