### PR TITLE
Harden OfManyTest coverage: strengthen the redundant differentiation test + cover composite ofMany

### DIFF
--- a/tests/Fixtures/Author.php
+++ b/tests/Fixtures/Author.php
@@ -53,6 +53,19 @@ class Author extends Model
             ->latestOfMany();
     }
 
+    // Composite (multi-column) `ofMany()`: the highest-priced book, with the
+    // most recent publication date breaking a price tie. Unlike the
+    // single-column relations above, this builds a nested `beforeQuery`
+    // callback on the one-of-many subquery.
+    public function latestBookByPriceThenDate() : HasOne
+    {
+        return $this->hasOne(Book::class)
+            ->ofMany([
+                "price" => "max",
+                "published_at" => "max",
+            ]);
+    }
+
     public function printers() : HasManyThrough
     {
         return $this->hasManyThrough(Printer::class, Book::class);

--- a/tests/Integration/CachedBuilder/OfManyTest.php
+++ b/tests/Integration/CachedBuilder/OfManyTest.php
@@ -1,8 +1,12 @@
 <?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
 
+use GeneaLabs\LaravelModelCaching\CacheKey;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class OfManyTest extends IntegrationTestCase
 {
@@ -74,13 +78,27 @@ class OfManyTest extends IntegrationTestCase
 
         $keys = $authors
             ->map(function (Author $author) {
-                $relation = $author->oldestBook();
+                // Build the relation the way eager loading does, inside
+                // `Relation::noConstraints()`. Calling `$author->oldestBook()`
+                // directly runs `HasOneOrMany::addConstraints()` while
+                // `isOneOfMany` is still false, which bakes a plain
+                // `where author_id = ?` onto the OUTER query — that ordinary
+                // clause alone would differentiate the two keys through
+                // `getWhereClauses()`, so the test would pass even with the
+                // deferred slug gutted. Suppressing it leaves the deferred
+                // `beforeQuery` join bindings as the only differentiator.
+                $relation = Relation::noConstraints(
+                    fn () => (new Author)->oldestBook(),
+                );
                 $relation->addEagerConstraints([$author]);
+                $query = $relation->getQuery()->getQuery();
 
-                return (new \GeneaLabs\LaravelModelCaching\CacheKey(
+                $this->assertSame([], $query->wheres ?? []);
+
+                return (new CacheKey(
                     [],
                     $relation->getRelated(),
-                    $relation->getQuery()->getQuery(),
+                    $query,
                     "",
                     [],
                     false,
@@ -88,7 +106,105 @@ class OfManyTest extends IntegrationTestCase
                     ->make(["*"]);
             });
 
+        $this->assertStringContainsString("-beforeQuery_", $keys->first());
+        $this->assertStringContainsString("-beforeQuery_", $keys->last());
         $this->assertNotEquals($keys->first(), $keys->last());
+    }
+
+    public function testCompositeOfManyEagerLoadMatchesUncachedResult()
+    {
+        $author = Author::factory()->create();
+        Book::factory()->create([
+            "author_id" => $author->id,
+            "price" => 10.00,
+            "published_at" => "2023-01-01 00:00:00",
+        ]);
+        Book::factory()->create([
+            "author_id" => $author->id,
+            "price" => 99.00,
+            "published_at" => "2021-01-01 00:00:00",
+        ]);
+        // Ties the highest price, so the second aggregate (published_at)
+        // decides — the composite path, not the single-column one.
+        $expectedBook = Book::factory()->create([
+            "author_id" => $author->id,
+            "price" => 99.00,
+            "published_at" => "2022-01-01 00:00:00",
+        ]);
+
+        $cachedAuthor = (new Author)
+            ->with("latestBookByPriceThenDate")
+            ->find($author->id);
+        $uncachedBook = (new UncachedBook)
+            ->where("author_id", $author->id)
+            ->orderByDesc("price")
+            ->orderByDesc("published_at")
+            ->first();
+
+        $this->assertNotNull($uncachedBook);
+        $this->assertNotNull($cachedAuthor->latestBookByPriceThenDate);
+        $this->assertEquals(
+            $expectedBook->id,
+            $cachedAuthor->latestBookByPriceThenDate->id,
+        );
+        $this->assertEquals(
+            $uncachedBook->id,
+            $cachedAuthor->latestBookByPriceThenDate->id,
+        );
+    }
+
+    public function testCompositeOfManyCacheKeyGenerationLeavesTheExecutedQueryUnchanged()
+    {
+        $author = (new Author)->orderBy("id")->first();
+
+        // Control: an identical relation that never has a cache key generated
+        // from it. Its compiled SQL is what the subject must still produce.
+        $controlQuery = $this
+            ->makeCompositeOfManyRelation($author)
+            ->getQuery()
+            ->getQuery();
+
+        $subject = $this->makeCompositeOfManyRelation($author);
+        $subjectQuery = $subject->getQuery()->getQuery();
+
+        // Key generation runs the deferred callbacks speculatively on a clone.
+        // The composite relation's callbacks mutate a nested subquery that the
+        // clone SHARES with the original, so do it twice: the second pass must
+        // observe the already-mutated subquery and still produce the same key.
+        $keys = collect([1, 2])
+            ->map(fn () => (new CacheKey(
+                [],
+                $subject->getRelated(),
+                $subjectQuery,
+                "",
+                [],
+                false,
+            ))
+                ->make(["*"]));
+
+        $this->assertStringContainsString("-beforeQuery_", $keys->first());
+        $this->assertSame($keys->first(), $keys->last());
+
+        $controlSql = $controlQuery->toSql();
+
+        // Guards the comparison below against passing on two empty or
+        // join-less strings: the joined subquery must really be there, and
+        // both aggregate columns must take part in it. Matches the join alias
+        // and the column names rather than aggregate syntax, so it survives
+        // grammar differences across the supported Laravel versions.
+        $this->assertStringContainsString("inner join", $controlSql);
+        $this->assertStringContainsString(
+            '"latestBookByPriceThenDate"',
+            $controlSql,
+        );
+        $this->assertStringContainsString("price", $controlSql);
+        $this->assertStringContainsString("published_at", $controlSql);
+
+        $this->assertSame($controlSql, $subjectQuery->toSql());
+        $this->assertSame(
+            $controlQuery->getBindings(),
+            $subjectQuery->getBindings(),
+        );
     }
 
     public function testDeferredQueriesWithDifferentBinaryBindingsProduceDifferentCacheKeys()
@@ -133,5 +249,18 @@ class OfManyTest extends IntegrationTestCase
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor",
             $key,
         );
+    }
+
+    // Builds the composite `ofMany()` relation through the eager-load path, so
+    // no ordinary `where` lands on the outer query and the deferred callbacks
+    // stay the only source of the join.
+    private function makeCompositeOfManyRelation(Author $author) : HasOne
+    {
+        $relation = Relation::noConstraints(
+            fn () => (new Author)->latestBookByPriceThenDate(),
+        );
+        $relation->addEagerConstraints([$author]);
+
+        return $relation;
     }
 }


### PR DESCRIPTION
## Summary
Implements #607. Test-only hardening of `tests/Integration/CachedBuilder/OfManyTest.php`. No source file changes.

## Changes

**Rewrote `testOfManyQueriesWithDifferentBindingsProduceDifferentCacheKeys`.**
It built the relation with `$author->oldestBook()`, which runs `HasOneOrMany::addConstraints()` while `isOneOfMany` is still false. That put a plain `where author_id = ?` on the outer query, so the two keys already diverged through `getWhereClauses()` — the test passed with the deferred slug gutted. It now builds the relation inside `Relation::noConstraints()`, the way eager loading does, so the deferred `beforeQuery` join bindings are the only differentiator. It also asserts the outer query carries no where clauses, and that both keys contain the `-beforeQuery_` slug.

**Added `testCompositeOfManyEagerLoadMatchesUncachedResult`.**
Covers composite multi-column `ofMany(["price" => "max", "published_at" => "max"])` through a new `Author::latestBookByPriceThenDate()` fixture relation. Two books tie on the top price so the second aggregate decides, which forces the composite path. Asserts the cached eager load returns the same book as the equivalent uncached query.

**Added `testCompositeOfManyCacheKeyGenerationLeavesTheExecutedQueryUnchanged`.**
Pins the idempotency guarantee documented in `src/CacheKey.php`. Generates the key twice from the same query, then compares the compiled SQL and bindings against a control relation that never had a key generated. The speculative pass mutates the shared nested subquery, so both passes must produce the same key and the executed SQL must come out byte-identical.

## Acceptance Criteria

- [x] Fix `testOfManyQueriesWithDifferentBindingsProduceDifferentCacheKeys` so it isolates the deferred-callback code path, or remove it as redundant. — Kept and rewritten; asserts the key contains `-beforeQuery_`.
- [x] The rewritten test must fail when the `getDeferredCallbacksSlug()` call in `CacheKey::make()` is removed. — Verified, see Test Plan.
- [x] Add a test covering composite multi-column `ofMany`, verifying cached and uncached results match. — `testCompositeOfManyEagerLoadMatchesUncachedResult`.
- [x] The composite test must exercise the speculative key-generation pass and assert the executed SQL/bindings are byte-identical across repeated key generation. — `testCompositeOfManyCacheKeyGenerationLeavesTheExecutedQueryUnchanged`.
- [x] All existing tests in `OfManyTest.php` and the `tests/Integration/CachedBuilder` suite continue to pass.
- [x] No changes to non-test source files.

## Test Plan

- [x] `OfManyTest` passes: 8 tests, 25 assertions.
- [x] Full `Integration,Feature` suite passes: 400 tests, 1034 assertions. The only 2 errors (`WhereJsonContainsTest::testWithInUsingCollectionQuery`, `…WithArrayValues`) are present on the base commit too and are unrelated to this change.
- [x] Mutation check — removed `$key .= $this->getDeferredCallbacksSlug();` from `CacheKey::make()`. The rewritten differentiation test goes red on `assertNotEquals` alone, with the `-beforeQuery_` assertions temporarily removed, proving the deferred path is the sole differentiator. `testCompositeOfManyCacheKeyGenerationLeavesTheExecutedQueryUnchanged` also goes red.
- [x] Mutation check — replaced `clone $this->query` with `$this->query` in `getDeferredCallbacksSlug()`. Both new composite tests go red; the idempotency test catches the second pass losing the slug.
- [x] Style: `pint --test` reports the same fixer set on these files before and after the change, so no new style drift.

Fixes #607